### PR TITLE
refactor merkle tree code and remove global pointers

### DIFF
--- a/cuda/Makefile
+++ b/cuda/Makefile
@@ -12,15 +12,16 @@ NVCC := /usr/local/cuda/bin/nvcc
 
 # flags
 INCL := -Itypes -Iposeidon -Iposeidon2 -Ikeccak -Imerkle -Iutil
+
 # for release
 CFLAGS := $(INCL) -Wall -Werror -O3 -march=native -fopenmp -fPIC
 CXXFLAGS := $(INCL) -Wall -Wno-error=sign-compare -std=c++11 -O3 -march=native -fopenmp -fPIC
 NVCCFLAGS := $(INCL) -Xcompiler -fopenmp -Xcompiler -fPIC -Xcompiler -O3 -arch=$(CUDA_ARCH)
 
 # for debug
-#CFLAGS := $(INCL) -Wall -Werror -march=native -fopenmp -fPIC -g
-#CXXFLAGS := $(INCL) -Wall -Wno-error=sign-compare -std=c++11 -march=native -fopenmp -fPIC -g
-#NVCCFLAGS := $(INCL) -Xcompiler -fopenmp -Xcompiler -fPIC -Xcompiler -g -arch=$(CUDA_ARCH) -g
+# CFLAGS := $(INCL) -Wall -Werror -march=native -fopenmp -fPIC -g
+# CXXFLAGS := $(INCL) -Wall -Wno-error=sign-compare -std=c++11 -march=native -fopenmp -fPIC -g
+# NVCCFLAGS := $(INCL) -Xcompiler -fopenmp -Xcompiler -fPIC -Xcompiler -g -arch=$(CUDA_ARCH) -g
 
 all: lib
 

--- a/cuda/merkle/merkle.cu
+++ b/cuda/merkle/merkle.cu
@@ -10,144 +10,50 @@
 #include "poseidon_bn128.h"
 #include "keccak.h"
 
-// #include "goldilocks.hpp"
-
+// TODO - benchmark and select best TPB
 #define TPB 64
 
-// pointers to the actual hash functions (could be Poseidon or Keccak)
-__device__ void (*gpu_hash_one_ptr)(gl64_t *input, u32 size, gl64_t *hash);
-__device__ void (*gpu_hash_two_ptr)(gl64_t *hash1, gl64_t *hash2, gl64_t *hash);
-
-__global__ void init_gpu_functions_poseidon_kernel()
+/*
+ * Selectors of GPU hash functions.
+ */
+__device__ void gpu_hash_one(gl64_t *lptr, uint32_t leaf_size, gl64_t *dptr, uint64_t hash_type)
 {
-    int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid > 0)
-        return;
-
-    gpu_hash_one_ptr = &gpu_poseidon_hash_one;
-    gpu_hash_two_ptr = &gpu_poseidon_hash_two;
-}
-
-__global__ void init_gpu_functions_poseidon2_kernel()
-{
-    int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid > 0)
-        return;
-
-    gpu_hash_one_ptr = &gpu_poseidon2_hash_one;
-    gpu_hash_two_ptr = &gpu_poseidon2_hash_two;
-}
-
-__global__ void init_gpu_functions_poseidon_bn128_kernel()
-{
-    int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid > 0)
-        return;
-
-    gpu_hash_one_ptr = &gpu_poseidon_bn128_hash_one;
-    gpu_hash_two_ptr = &gpu_poseidon_bn128_hash_two;
-}
-
-__global__ void init_gpu_functions_keccak_kernel()
-{
-    int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid > 0)
-        return;
-
-    gpu_hash_one_ptr = &gpu_keccak_hash_one;
-    gpu_hash_two_ptr = &gpu_keccak_hash_two;
-}
-
-void init_gpu_functions(u64 hash_type)
-{
-    static int64_t initialize_hash_type = -1;
-
-    if (initialize_hash_type == -1 || initialize_hash_type != hash_type)
+    switch (hash_type)
     {
-        initialize_hash_type = hash_type;
-
-        int nDevices = 0;
-        CHECKCUDAERR(cudaGetDeviceCount(&nDevices));
-
-        for (int d = 0; d < nDevices; d++)
-        {
-            CHECKCUDAERR(cudaSetDevice(d));
-            switch (hash_type)
-            {
-            case 0:
-                init_gpu_functions_poseidon_kernel<<<1, 1>>>();
-                cpu_hash_one_ptr = &cpu_poseidon_hash_one;
-                cpu_hash_two_ptr = &cpu_poseidon_hash_two;
-                break;
-            case 1:
-                init_gpu_functions_keccak_kernel<<<1, 1>>>();
-                cpu_hash_one_ptr = &cpu_keccak_hash_one;
-                cpu_hash_two_ptr = &cpu_keccak_hash_two;
-                break;
-            case 2:
-                init_gpu_functions_poseidon_bn128_kernel<<<1, 1>>>();
-                cpu_hash_one_ptr = &cpu_poseidon_bn128_hash_one;
-                cpu_hash_two_ptr = &cpu_poseidon_bn128_hash_two;
-                break;
-            case 3:
-                init_gpu_functions_poseidon2_kernel<<<1, 1>>>();
-                cpu_hash_one_ptr = &cpu_poseidon2_hash_one;
-                cpu_hash_two_ptr = &cpu_poseidon2_hash_two;
-                break;
-            default:
-                init_gpu_functions_poseidon_kernel<<<1, 1>>>();
-                cpu_hash_one_ptr = &cpu_poseidon_hash_one;
-                cpu_hash_two_ptr = &cpu_poseidon_hash_two;
-            }
-        }
+    case 0:
+        return gpu_poseidon_hash_one(lptr, leaf_size, dptr);
+    case 1:
+        return gpu_keccak_hash_one(lptr, leaf_size, dptr);
+    case 2:
+        return gpu_poseidon_bn128_hash_one(lptr, leaf_size, dptr);
+    case 3:
+        return gpu_poseidon2_hash_one(lptr, leaf_size, dptr);
+    default:
+        return;
     }
 }
 
-void init_gpu_functions(u64 hash_type, int gpu_id)
+__device__ void gpu_hash_two(gl64_t *hash1, gl64_t *hash2, gl64_t *hash, uint64_t hash_type)
 {
-    static int64_t initialize_hash_type_one = -1;
-
-    if (initialize_hash_type_one == -1 || initialize_hash_type_one != hash_type)
+    switch (hash_type)
     {
-        initialize_hash_type_one = hash_type;
-
-        CHECKCUDAERR(cudaSetDevice(gpu_id));
-        switch (hash_type)
-        {
-        case 0:
-            init_gpu_functions_poseidon_kernel<<<1, 1>>>();
-            cpu_hash_one_ptr = &cpu_poseidon_hash_one;
-            cpu_hash_two_ptr = &cpu_poseidon_hash_two;
-            break;
-        case 1:
-            init_gpu_functions_keccak_kernel<<<1, 1>>>();
-            cpu_hash_one_ptr = &cpu_keccak_hash_one;
-            cpu_hash_two_ptr = &cpu_keccak_hash_two;
-            break;
-        case 2:
-            init_gpu_functions_poseidon_bn128_kernel<<<1, 1>>>();
-            cpu_hash_one_ptr = &cpu_poseidon_bn128_hash_one;
-            cpu_hash_two_ptr = &cpu_poseidon_bn128_hash_two;
-            break;
-        case 3:
-            init_gpu_functions_poseidon2_kernel<<<1, 1>>>();
-            cpu_hash_one_ptr = &cpu_poseidon2_hash_one;
-            cpu_hash_two_ptr = &cpu_poseidon2_hash_two;
-            break;
-        default:
-            init_gpu_functions_poseidon_kernel<<<1, 1>>>();
-            cpu_hash_one_ptr = &cpu_poseidon_hash_one;
-            cpu_hash_two_ptr = &cpu_poseidon_hash_two;
-        }
+    case 0:
+        return gpu_poseidon_hash_two(hash1, hash2, hash);
+    case 1:
+        return gpu_keccak_hash_two(hash1, hash2, hash);
+    case 2:
+        return gpu_poseidon_bn128_hash_two(hash1, hash2, hash);
+    case 3:
+        return gpu_poseidon2_hash_two(hash1, hash2, hash);
+    default:
+        return;
     }
 }
-
-// GPU kernels
 
 /*
  * Compute only leaves hashes with direct mapping (digest i corresponds to leaf i).
  */
-__global__ void compute_leaves_hashes_direct(u64 *leaves, u32 leaves_count, u32 leaf_size, u64 *digests_buf)
+__global__ void compute_leaves_hashes_direct(u64 *leaves, u32 leaves_count, u32 leaf_size, u64 *digests_buf, uint64_t hash_type)
 {
     int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= leaves_count)
@@ -155,7 +61,7 @@ __global__ void compute_leaves_hashes_direct(u64 *leaves, u32 leaves_count, u32 
 
     u64 *lptr = leaves + (tid * leaf_size);
     u64 *dptr = digests_buf + (tid * HASH_SIZE_U64);
-    gpu_hash_one_ptr((gl64_t *)lptr, leaf_size, (gl64_t *)dptr);
+    gpu_hash_one((gl64_t *)lptr, leaf_size, (gl64_t *)dptr, hash_type);
 
     // if with stride
     // u64 *lptr = leaves + tid;
@@ -166,7 +72,7 @@ __global__ void compute_leaves_hashes_direct(u64 *leaves, u32 leaves_count, u32 
 /*
  * Compute only leaves hashes with direct mapping per subtree over the entire digest buffer.
  */
-__global__ void compute_leaves_hashes_linear_all(u64 *leaves, u32 leaves_count, u32 leaf_size, u64 *digests_buf, u32 subtree_leaves_len, u32 subtree_digests_len)
+__global__ void compute_leaves_hashes_linear_all(u64 *leaves, u32 leaves_count, u32 leaf_size, u64 *digests_buf, u32 subtree_leaves_len, u32 subtree_digests_len, uint64_t hash_type)
 {
     int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= leaves_count)
@@ -179,7 +85,8 @@ __global__ void compute_leaves_hashes_linear_all(u64 *leaves, u32 leaves_count, 
 
     u64 *lptr = leaves + (tid * leaf_size);
     u64 *dptr = digests_buf + didx * HASH_SIZE_U64;
-    gpu_hash_one_ptr((gl64_t *)lptr, leaf_size, (gl64_t *)dptr);
+
+    gpu_hash_one((gl64_t *)lptr, leaf_size, (gl64_t *)dptr, hash_type);
 
     // if with stride
     // u64 *lptr = leaves + tid;
@@ -190,7 +97,7 @@ __global__ void compute_leaves_hashes_linear_all(u64 *leaves, u32 leaves_count, 
 /*
  * Compute only leaves hashes with direct mapping per subtree (one subtree per GPU).
  */
-__global__ void compute_leaves_hashes_linear_per_gpu(u64 *leaves, u32 leaf_size, u64 *digests_buf, u32 subtree_leaves_len, u32 subtree_digests_len)
+__global__ void compute_leaves_hashes_linear_per_gpu(u64 *leaves, u32 leaf_size, u64 *digests_buf, u32 subtree_leaves_len, u32 subtree_digests_len, uint64_t hash_type)
 {
     int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= subtree_leaves_len)
@@ -200,13 +107,13 @@ __global__ void compute_leaves_hashes_linear_per_gpu(u64 *leaves, u32 leaf_size,
     // printf("%d\n", didx);
     u64 *lptr = leaves + (tid * leaf_size);
     u64 *dptr = digests_buf + (didx * HASH_SIZE_U64);
-    gpu_hash_one_ptr((gl64_t *)lptr, leaf_size, (gl64_t *)dptr);
+    gpu_hash_one((gl64_t *)lptr, leaf_size, (gl64_t *)dptr, hash_type);
 }
 
 /*
  * Compute leaves hashes with indirect mapping (digest at digest_idx[i] corresponds to leaf i).
  */
-__global__ void compute_leaves_hashes(u64 *leaves, u32 leaves_count, u32 leaf_size, u64 *digests_buf, u32 *digest_idx)
+__global__ void compute_leaves_hashes(u64 *leaves, u32 leaves_count, u32 leaf_size, u64 *digests_buf, u32 *digest_idx, uint64_t hash_type)
 {
     int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= leaves_count)
@@ -214,13 +121,13 @@ __global__ void compute_leaves_hashes(u64 *leaves, u32 leaves_count, u32 leaf_si
 
     u64 *lptr = leaves + (tid * leaf_size);
     u64 *dptr = digests_buf + digest_idx[tid] * HASH_SIZE_U64;
-    gpu_hash_one_ptr((gl64_t *)lptr, leaf_size, (gl64_t *)dptr);
+    gpu_hash_one((gl64_t *)lptr, leaf_size, (gl64_t *)dptr, hash_type);
 }
 
 /*
  * Compute leaves hashes with indirect mapping and offset (digest at digest_idx[i] corresponds to leaf i).
  */
-__global__ void compute_leaves_hashes_offset(u64 *leaves, u32 leaves_count, u32 leaf_size, u64 *digests_buf, u32 *digest_idx, u64 offset)
+__global__ void compute_leaves_hashes_offset(u64 *leaves, u32 leaves_count, u32 leaf_size, u64 *digests_buf, u32 *digest_idx, u64 offset, uint64_t hash_type)
 {
     int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= leaves_count)
@@ -228,63 +135,13 @@ __global__ void compute_leaves_hashes_offset(u64 *leaves, u32 leaves_count, u32 
 
     u64 *lptr = leaves + (tid * leaf_size);
     u64 *dptr = digests_buf + (digest_idx[tid] - offset) * HASH_SIZE_U64;
-    gpu_hash_one_ptr((gl64_t *)lptr, leaf_size, (gl64_t *)dptr);
-}
-
-/*
- * Compute internal Merkle tree hashes based on precomputed indexes. Cover all rounds.
- */
-__global__ void compute_internal_hashes(u64 *digests_buf, u32 max_rounds, u32 max_round_size, u32 *round_size, HashTask *internal_index, u32 round_threshold)
-{
-    int tid = blockIdx.x * blockDim.x + threadIdx.x;
-
-    for (int r = max_rounds; r > round_threshold; r--)
-    {
-        if (tid < round_size[r])
-        {
-            HashTask *ht = &internal_index[r * max_round_size + tid];
-            u64 *dptr = digests_buf + (ht->target_index * HASH_SIZE_U64);
-            u64 *sptr1 = digests_buf + (ht->left_index * HASH_SIZE_U64);
-            u64 *sptr2 = digests_buf + (ht->right_index * HASH_SIZE_U64);
-            gpu_hash_two_ptr((gl64_t *)sptr1, (gl64_t *)sptr2, (gl64_t *)dptr);
-        }
-        // __syncthreads();
-    }
-}
-
-/*
- * Compute internal Merkle tree hashes based on precomputed indexes. Only one round.
- */
-__global__ void compute_internal_hashes_per_round(u64 *digests_buf, u32 round_size, u32 round_idx, u32 max_round_size, HashTask *internal_index)
-{
-    int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid >= round_size)
-        return;
-
-    HashTask *ht = &internal_index[round_idx * max_round_size + tid];
-    u64 *dptr = digests_buf + (ht->target_index * HASH_SIZE_U64);
-    u64 *sptr1 = digests_buf + (ht->left_index * HASH_SIZE_U64);
-    u64 *sptr2 = digests_buf + (ht->right_index * HASH_SIZE_U64);
-    gpu_hash_two_ptr((gl64_t *)sptr1, (gl64_t *)sptr2, (gl64_t *)dptr);
-}
-
-__global__ void compute_caps_hashes_per_round(u64 *caps_buf, u64 *digests_buf, u32 round_size, u32 round_idx, u32 max_round_size, HashTask *internal_index)
-{
-    int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid >= round_size)
-        return;
-
-    HashTask *ht = &internal_index[round_idx * max_round_size + tid];
-    u64 *dptr = caps_buf + (ht->target_index * HASH_SIZE_U64);
-    u64 *sptr1 = digests_buf + (ht->left_index * HASH_SIZE_U64);
-    u64 *sptr2 = digests_buf + (ht->right_index * HASH_SIZE_U64);
-    gpu_hash_two_ptr((gl64_t *)sptr1, (gl64_t *)sptr2, (gl64_t *)dptr);
+    gpu_hash_one((gl64_t *)lptr, leaf_size, (gl64_t *)dptr, hash_type);
 }
 
 /*
  * Compute internal Merkle tree hashes in linear structure. Only one round.
  */
-__global__ void compute_internal_hashes_linear_all(u64 *digests_buf, u32 round_size, u32 last_idx, u32 subtree_count, u32 subtree_digests_len)
+__global__ void compute_internal_hashes_linear_all(u64 *digests_buf, u32 round_size, u32 last_idx, u32 subtree_count, u32 subtree_digests_len, uint64_t hash_type)
 {
     int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= round_size * subtree_count)
@@ -299,10 +156,10 @@ __global__ void compute_internal_hashes_linear_all(u64 *digests_buf, u32 round_s
     u64 *sptr2 = dptrs + (2 * (idx + 1) + 1 + last_idx) * HASH_SIZE_U64;
 
     // compute hash
-    gpu_hash_two_ptr((gl64_t *)sptr1, (gl64_t *)sptr2, (gl64_t *)dptr);
+    gpu_hash_two((gl64_t *)sptr1, (gl64_t *)sptr2, (gl64_t *)dptr, hash_type);
 }
 
-__global__ void compute_internal_hashes_linear_per_gpu(u64 *digests_buf, u32 round_size, u32 last_idx)
+__global__ void compute_internal_hashes_linear_per_gpu(u64 *digests_buf, u32 round_size, u32 last_idx, uint64_t hash_type)
 {
     int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= round_size)
@@ -315,10 +172,10 @@ __global__ void compute_internal_hashes_linear_per_gpu(u64 *digests_buf, u32 rou
     u64 *sptr2 = dptrs + (2 * (tid + 1) + 1 + last_idx) * HASH_SIZE_U64;
 
     // compute hash
-    gpu_hash_two_ptr((gl64_t *)sptr1, (gl64_t *)sptr2, (gl64_t *)dptr);
+    gpu_hash_two((gl64_t *)sptr1, (gl64_t *)sptr2, (gl64_t *)dptr, hash_type);
 }
 
-__global__ void compute_caps_hashes_linear(u64 *caps_buf, u64 *digests_buf, u64 cap_buf_size, u64 subtree_digests_len)
+__global__ void compute_caps_hashes_linear(u64 *caps_buf, u64 *digests_buf, u64 cap_buf_size, u64 subtree_digests_len, uint64_t hash_type)
 {
     int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= cap_buf_size)
@@ -327,516 +184,7 @@ __global__ void compute_caps_hashes_linear(u64 *caps_buf, u64 *digests_buf, u64 
     // compute hash
     u64 *sptr1 = digests_buf + tid * subtree_digests_len * HASH_SIZE_U64;
     u64 *dptr = caps_buf + tid * HASH_SIZE_U64;
-    gpu_hash_two_ptr((gl64_t *)sptr1, (gl64_t *)(sptr1 + HASH_SIZE_U64), (gl64_t *)dptr);
-}
-
-/*
- * Compute internal Merkle tree hashes in linear structure on the entire buffer.
- */
-__global__ void compute_internal_hashes_linear(u64 *digests_buf, u32 round_size, u32 last_idx)
-{
-    int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid >= round_size)
-        return;
-
-    u64 *dptr = digests_buf + tid * HASH_SIZE_U64;
-    u64 *sptr1 = digests_buf + (2 * (tid + 1) + last_idx) * HASH_SIZE_U64;
-    u64 *sptr2 = digests_buf + (2 * (tid + 1) + 1 + last_idx) * HASH_SIZE_U64;
-    gpu_hash_two_ptr((gl64_t *)sptr1, (gl64_t *)sptr2, (gl64_t *)dptr);
-}
-
-// CPU functions
-void fill_digests_buf_in_rounds_in_c_on_gpu(
-    u64 digests_buf_size,
-    u64 cap_buf_size,
-    u64 leaves_buf_size,
-    u64 leaf_size,
-    u64 cap_height)
-{
-    u64 *gpu_leaves;
-    u64 *gpu_digests;
-    u64 *gpu_caps;
-    u32 *gpu_indexes;
-    u32 *gpu_round_size;
-    HashTask *gpu_internal_indexes;
-
-    u32 leaves_size_bytes = leaves_buf_size * leaf_size * 8;
-    CHECKCUDAERR(cudaMalloc(&gpu_leaves, leaves_size_bytes));
-    CHECKCUDAERR(cudaMemcpyAsync(gpu_leaves, global_leaves_buf, leaves_size_bytes, cudaMemcpyHostToDevice));
-
-    if (cap_buf_size == leaves_buf_size)
-    {
-        u32 digests_size_bytes = cap_buf_size * HASH_SIZE_U64 * sizeof(u64);
-        CHECKCUDAERR(cudaMalloc(&gpu_digests, digests_size_bytes));
-        compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>(gpu_leaves, leaves_buf_size, leaf_size, gpu_digests);
-        CHECKCUDAERR(cudaMemcpy(global_cap_buf, gpu_digests, digests_size_bytes, cudaMemcpyDeviceToHost));
-
-        // free
-        cudaFree(gpu_digests);
-        cudaFree(gpu_leaves);
-
-        return;
-    }
-
-    // 1.1 copy leaves from CPU to GPU
-    // 1.2 (in parallel) run fill_tree_get_index on CPU
-    // 2.1 compute leaf hashes on GPU
-    // 2.2 (in parallel) copy task index data to GPU
-    // 3. compute internal hashes on GPU
-    // 4. copy data from GPU to CPU
-    // 5. compute cap hashes on CPU
-
-    u64 subtree_digests_len = digests_buf_size >> cap_height;
-    u64 subtree_leaves_len = leaves_buf_size >> cap_height;
-    u64 digests_chunks = digests_buf_size / subtree_digests_len;
-    u64 leaves_chunks = leaves_buf_size / subtree_leaves_len;
-    assert(digests_chunks == cap_buf_size);
-    assert(digests_chunks == leaves_chunks);
-
-    // 1.2 (in parallel) run fill_tree_get_index on CPU
-    for (u64 k = 0; k < cap_buf_size; k++)
-    {
-        fill_subtree_get_index(k, k * subtree_digests_len, subtree_digests_len, k * subtree_leaves_len, subtree_leaves_len, leaf_size, 0);
-    }
-
-    u32 digests_size_bytes = digests_buf_size * HASH_SIZE_U64 * sizeof(u64);
-    u32 caps_size_bytes = cap_buf_size * HASH_SIZE_U64 * sizeof(u64);
-    CHECKCUDAERR(cudaMalloc(&gpu_digests, digests_size_bytes));
-    CHECKCUDAERR(cudaMalloc(&gpu_caps, caps_size_bytes));
-    CHECKCUDAERR(cudaMalloc(&gpu_indexes, leaves_buf_size * sizeof(u32)));
-    CHECKCUDAERR(cudaMalloc(&gpu_internal_indexes, (global_max_round + 1) * global_max_round_size * sizeof(HashTask)));
-    CHECKCUDAERR(cudaMalloc(&gpu_round_size, (global_max_round + 1) * sizeof(u32)));
-
-    // 2.1 compute leaf hashes on GPU
-    CHECKCUDAERR(cudaMemcpyAsync(gpu_indexes, global_leaf_index, leaves_buf_size * sizeof(u32), cudaMemcpyHostToDevice));
-    CHECKCUDAERR(cudaMemcpyAsync(gpu_round_size, global_round_size, (global_max_round + 1) * sizeof(u32), cudaMemcpyHostToDevice));
-    CHECKCUDAERR(cudaMemcpyAsync((void *)gpu_internal_indexes, (void *)global_internal_index, (global_max_round + 1) * global_max_round_size * sizeof(HashTask), cudaMemcpyHostToDevice));
-    compute_leaves_hashes<<<leaves_buf_size / TPB + 1, TPB>>>(gpu_leaves, leaves_buf_size, leaf_size, gpu_digests, gpu_indexes);
-
-    int r = global_max_round;
-    for (; global_round_size[r] > TPB; r--)
-    {
-        compute_internal_hashes_per_round<<<global_round_size[r] / TPB, TPB>>>(gpu_digests, global_round_size[r], r, global_max_round_size, gpu_internal_indexes);
-    }
-
-    for (; r > 0; r--)
-    {
-        compute_internal_hashes_per_round<<<1, global_round_size[r]>>>(gpu_digests, global_round_size[r], r, global_max_round_size, gpu_internal_indexes);
-    }
-
-    CHECKCUDAERR(cudaMemcpyAsync(global_digests_buf, gpu_digests, digests_size_bytes, cudaMemcpyDeviceToHost));
-
-    compute_caps_hashes_per_round<<<1, global_round_size[0]>>>(gpu_caps, gpu_digests, global_round_size[0], 0, global_max_round_size, gpu_internal_indexes);
-
-    CHECKCUDAERR(cudaMemcpy(global_cap_buf, gpu_caps, caps_size_bytes, cudaMemcpyDeviceToHost));
-
-    // free
-    cudaFree(gpu_digests);
-    cudaFree(gpu_caps);
-    cudaFree(gpu_indexes);
-    cudaFree(gpu_leaves);
-    cudaFree(gpu_internal_indexes);
-    cudaFree(gpu_round_size);
-}
-
-void fill_digests_buf_in_rounds_in_c_on_gpu_v1(
-    u64 digests_buf_size,
-    u64 cap_buf_size,
-    u64 leaves_buf_size,
-    u64 leaf_size,
-    u64 cap_height)
-{
-    u64 *gpu_leaves;
-    u64 *gpu_digests;
-    u32 *gpu_indexes;
-    u32 *gpu_round_size;
-    HashTask *gpu_internal_indexes;
-
-    u32 leaves_size_bytes = leaves_buf_size * leaf_size * 8;
-    CHECKCUDAERR(cudaMalloc(&gpu_leaves, leaves_size_bytes));
-    CHECKCUDAERR(cudaMemcpyAsync(gpu_leaves, global_leaves_buf, leaves_size_bytes, cudaMemcpyHostToDevice));
-
-    if (cap_buf_size == leaves_buf_size)
-    {
-        u32 digests_size_bytes = cap_buf_size * HASH_SIZE_U64 * sizeof(u64);
-        CHECKCUDAERR(cudaMalloc(&gpu_digests, digests_size_bytes));
-        compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>(gpu_leaves, leaves_buf_size, leaf_size, gpu_digests);
-        CHECKCUDAERR(cudaMemcpy(global_cap_buf, gpu_digests, digests_size_bytes, cudaMemcpyDeviceToHost));
-
-        // free
-        cudaFree(gpu_digests);
-        cudaFree(gpu_leaves);
-
-        return;
-    }
-
-    // 1.1 copy leaves from CPU to GPU
-    // 1.2 (in parallel) run fill_tree_get_index on CPU
-    // 2.1 compute leaf hashes on GPU
-    // 2.2 (in parallel) copy task index data to GPU
-    // 3. compute internal hashes on GPU
-    // 4. copy data from GPU to CPU
-    // 5. compute cap hashes on CPU
-
-    u64 subtree_digests_len = digests_buf_size >> cap_height;
-    u64 subtree_leaves_len = leaves_buf_size >> cap_height;
-    u64 digests_chunks = digests_buf_size / subtree_digests_len;
-    u64 leaves_chunks = leaves_buf_size / subtree_leaves_len;
-    assert(digests_chunks == cap_buf_size);
-    assert(digests_chunks == leaves_chunks);
-
-    // 1.2 (in parallel) run fill_tree_get_index on CPU
-    for (u64 k = 0; k < cap_buf_size; k++)
-    {
-        fill_subtree_get_index(k, k * subtree_digests_len, subtree_digests_len, k * subtree_leaves_len, subtree_leaves_len, leaf_size, 0);
-    }
-
-    u32 digests_size_bytes = digests_buf_size * HASH_SIZE_U64 * sizeof(u64);
-    CHECKCUDAERR(cudaMalloc(&gpu_digests, digests_size_bytes));
-    CHECKCUDAERR(cudaMalloc(&gpu_indexes, leaves_buf_size * sizeof(u32)));
-    CHECKCUDAERR(cudaMalloc(&gpu_internal_indexes, (global_max_round + 1) * global_max_round_size * sizeof(HashTask)));
-    CHECKCUDAERR(cudaMalloc(&gpu_round_size, (global_max_round + 1) * sizeof(u32)));
-
-    // 2.1 compute leaf hashes on GPU
-    CHECKCUDAERR(cudaMemcpyAsync(gpu_indexes, global_leaf_index, leaves_buf_size * sizeof(u32), cudaMemcpyHostToDevice));
-    CHECKCUDAERR(cudaMemcpyAsync(gpu_round_size, global_round_size, (global_max_round + 1) * sizeof(u32), cudaMemcpyHostToDevice));
-    CHECKCUDAERR(cudaMemcpyAsync((void *)gpu_internal_indexes, (void *)global_internal_index, (global_max_round + 1) * global_max_round_size * sizeof(HashTask), cudaMemcpyHostToDevice));
-    compute_leaves_hashes<<<leaves_buf_size / TPB + 1, TPB>>>(gpu_leaves, leaves_buf_size, leaf_size, gpu_digests, gpu_indexes);
-
-    // compute_internal_hashes<<<max_round_size / TPB, TPB>>>(gpu_digests, max_round, max_round_size, gpu_round_size, gpu_internal_indexes, TPB);
-
-    int r = global_max_round;
-    for (; global_round_size[r] > TPB; r--)
-    {
-        compute_internal_hashes_per_round<<<global_round_size[r] / TPB, TPB>>>(gpu_digests, global_round_size[r], r, global_max_round_size, gpu_internal_indexes);
-    }
-
-    CHECKCUDAERR(cudaMemcpy(global_digests_buf, gpu_digests, digests_size_bytes, cudaMemcpyDeviceToHost));
-
-    // internal rounds on digest buffer on CPU -- for testing only!
-    // for (int r = max_round-1; r > 0; r--) {
-
-    for (; r > 0; r--)
-    {
-        for (int i = 0; i < global_round_size[r]; i++)
-        {
-            HashTask *ht = &global_internal_index[r * global_max_round_size + i];
-            cpu_hash_two_ptr(global_digests_buf + (ht->left_index * HASH_SIZE_U64), global_digests_buf + (ht->right_index * HASH_SIZE_U64), global_digests_buf + (ht->target_index * HASH_SIZE_U64));
-        }
-    }
-
-    // cap buffer (on CPU)
-    for (int i = 0; i < global_round_size[0]; i++)
-    {
-        HashTask *ht = &global_internal_index[i];
-        cpu_hash_two_ptr(global_digests_buf + (ht->left_index * HASH_SIZE_U64), global_digests_buf + (ht->right_index * HASH_SIZE_U64), global_cap_buf + (ht->target_index * HASH_SIZE_U64));
-    }
-
-    // free
-    cudaFree(gpu_digests);
-    cudaFree(gpu_indexes);
-    cudaFree(gpu_leaves);
-    cudaFree(gpu_internal_indexes);
-    cudaFree(gpu_round_size);
-}
-
-void compute_size_per_gpu(u64 total, u64 ndev, u64 *per_dev, u64 *last_dev)
-{
-    u64 x_per_dev = total / ndev + 1;
-    if (x_per_dev * ndev > total)
-    {
-        x_per_dev = total / ndev;
-    }
-    u64 x_last_dev = total - (ndev - 1) * x_per_dev;
-    assert(x_last_dev <= total);
-    *per_dev = x_per_dev;
-    *last_dev = x_last_dev;
-}
-
-/*
-void fill_digests_buf_in_rounds_in_c_on_multigpu(
-    u64 digests_buf_size,
-    u64 cap_buf_size,
-    u64 leaves_buf_size,
-    u64 leaf_size,
-    u64 cap_height,
-    u64 ngpus)
-{
-    u64 *gpu_leaves[16];
-    u64 *gpu_digests[16];
-    u64 *gpu_caps[16];
-    u32 *gpu_indexes[16];
-    u32 *gpu_round_size[16];
-    HashTask *gpu_internal_indexes[16];
-    cudaStream_t gpu_stream[16];
-
-    int nDevices = 0;
-    CHECKCUDAERR(cudaGetDeviceCount(&nDevices));
-    assert(ngpus <= nDevices);
-
-    u64 leaves_per_gpu;
-    u64 leaves_last_gpu;
-    compute_size_per_gpu(leaves_buf_size, ngpus, &leaves_per_gpu, &leaves_last_gpu);
-    u64 leaves_size_bytes_per_gpu = leaves_per_gpu * leaf_size * sizeof(u64);
-    u64 leaves_size_bytes_last_gpu = leaves_last_gpu * leaf_size * sizeof(u64);
-
-    for(int d = 0; d < ngpus; d++)
-    {
-        u64 cnt = (d == ngpus - 1) ? leaves_last_gpu : leaves_per_gpu;
-        u64 sz = cnt * sizeof(u64);
-        CHECKCUDAERR(cudaStreamCreate(gpu_stream + d));
-        CHECKCUDAERR(cudaMalloc(&gpu_leaves[d], sz));
-        CHECKCUDAERR(cudaMemcpyAsync(gpu_leaves[d], global_leaves_buf + d * cnt, sz, cudaMemcpyHostToDevice, gpu_stream[d]));
-    }
-
-    if (cap_buf_size == leaves_buf_size)
-    {
-        u64 digests_size_bytes = leaves_buf_size * HASH_SIZE_U64 * sizeof(u64);
-
-        u64 digests_per_gpu;
-        u64 digests_last_gpu;
-        compute_size_per_gpu(leaves_buf_size, ngpus, &digests_per_gpu, &digests_last_gpu);
-        for(int d = 0; d < ngpus; d++)
-        {
-            u64 digests_cnt = (d == ngpus - 1) ? digests_last_gpu : digests_per_gpu;
-            u64 digests_size_bytes = digests_cnt * HASH_SIZE_U64 * sizeof(u64);
-            u64 leaves_cnt = (d == ngpus - 1) ? leaves_last_gpu : leaves_per_gpu;
-            CHECKCUDAERR(cudaSetDevice(d));
-            CHECKCUDAERR(cudaMalloc(&gpu_digests[d], digests_size_bytes));
-            compute_leaves_hashes_direct<<<leaves_cnt / TPB + 1, TPB, 0, gpu_stream[d]>>>(gpu_leaves[d], leaves_cnt, leaf_size, gpu_digests[d]);
-            CHECKCUDAERR(cudaMemcpyAsync(global_cap_buf + d * digests_cnt * HASH_SIZE, gpu_digests[d], digests_size_bytes, cudaMemcpyDeviceToHost, gpu_stream[d]));
-        }
-        for(int d = 0; d < ngpus; d++)
-        {
-            CHECKCUDAERR(cudaSetDevice(d));
-            CHECKCUDAERR(cudaStreamSynchronize(gpu_stream[d]));
-            cudaFree(gpu_digests[d]);
-            cudaFree(gpu_leaves[d]);
-            CHECKCUDAERR(cudaStreamDestroy(gpu_stream[d]));
-        }
-        return;
-    }
-
-    // 1.1 copy leaves from CPU to GPU
-    // 1.2 (in parallel) run fill_tree_get_index on CPU
-    // 2.1 compute leaf hashes on GPU
-    // 2.2 (in parallel) copy task index data to GPU
-    // 3. compute internal hashes on GPU
-    // 4. copy data from GPU to CPU
-    // 5. compute cap hashes on CPU
-
-    u64 subtree_digests_len = digests_buf_size >> cap_height;
-    u64 subtree_leaves_len = leaves_buf_size >> cap_height;
-    u64 digests_chunks = digests_buf_size / subtree_digests_len;
-    u64 leaves_chunks = leaves_buf_size / subtree_leaves_len;
-    assert(digests_chunks == cap_buf_size);
-    assert(digests_chunks == leaves_chunks);
-
-    // 1.2 (in parallel) run fill_tree_get_index on CPU
-    for (u64 k = 0; k < cap_buf_size; k++)
-    {
-        fill_subtree_get_index(k, k * subtree_digests_len, subtree_digests_len, k * subtree_leaves_len, subtree_leaves_len, leaf_size, 0);
-    }
-
-    u64 digests_per_gpu;
-    u64 digests_last_gpu;
-    compute_size_per_gpu(digests_buf_size, ngpus, &digests_per_gpu, &digests_last_gpu);
-    u64 caps_per_gpu;
-    u64 caps_last_gpu;
-    compute_size_per_gpu(cap_buf_size, ngpus, &caps_per_gpu, &caps_last_gpu);
-
-    for(int d = 0; d < ngpus; d++)
-    {
-        u64 digests_size = ((d == ngpus - 1) ? digests_last_gpu : digests_per_gpu) * HASH_SIZE_U64 * sizeof(u64);
-        u64 leaves_cnt = (d == ngpus - 1) ? leaves_last_gpu : leaves_per_gpu;
-
-        CHECKCUDAERR(cudaSetDevice(d));
-        CHECKCUDAERR(cudaMalloc(&gpu_digests[d], digests_size));
-        CHECKCUDAERR(cudaMalloc(&gpu_indexes[d], leaves_cnt * sizeof(u32)));
-        CHECKCUDAERR(cudaMalloc(&gpu_internal_indexes[d], (global_max_round + 1) * global_max_round_size * sizeof(HashTask)));
-        CHECKCUDAERR(cudaMalloc(&gpu_round_size[d], (global_max_round + 1) * sizeof(u32)));
-    }
-    if (cap_buf_size > (1 << 20))
-    {
-        for(int d = 0; d < ngpus; d++)
-        {
-            u64 caps_size = ((d == ngpus - 1) ? caps_last_gpu : caps_per_gpu) * HASH_SIZE_U64 * sizeof(u64);
-            CHECKCUDAERR(cudaSetDevice(d));
-            CHECKCUDAERR(cudaMalloc(&gpu_caps[d], caps_size));
-        }
-    }
-    else
-    {
-        u32 caps_size_bytes = cap_buf_size * HASH_SIZE_U64 * sizeof(u64);
-        CHECKCUDAERR(cudaSetDevice(0));
-        CHECKCUDAERR(cudaMalloc(&gpu_caps[0], caps_size_bytes));
-    }
-
-    // 2.1 compute leaf hashes on GPU
-    for(int d = 0; d < ngpus; d++)
-    {
-        u64 leaves_cnt = (d == ngpus - 1) ? leaves_last_gpu : leaves_per_gpu;
-        u64 digests_size_bytes = leaves_cnt * HASH_SIZE_U64 * sizeof(u64);
-
-        compute_leaves_hashes_direct<<<leaves_cnt / TPB + 1, TPB, 0, gpu_stream[d]>>>(gpu_leaves[d], leaves_cnt, leaf_size, gpu_digests[d]);
-        CHECKCUDAERR(cudaMemcpyAsync(global_cap_buf + d * leaves_cnt * HASH_SIZE_U64, gpu_digests[d], digests_size_bytes, cudaMemcpyDeviceToHost, gpu_stream[d]));
-
-        CHECKCUDAERR(cudaMemcpyAsync(gpu_indexes[d], global_leaf_index + d * leaves_cnt, leaves_cnt * sizeof(u32), cudaMemcpyHostToDevice, gpu_stream[d]));
-        CHECKCUDAERR(cudaMemcpyAsync(gpu_round_size[d], global_round_size + d, (global_max_round + 1) * sizeof(u32), cudaMemcpyHostToDevice, gpu_stream[d]));
-        CHECKCUDAERR(cudaMemcpyAsync((void *)gpu_internal_indexes, (void *)global_internal_index, (global_max_round + 1) * global_max_round_size * sizeof(HashTask), cudaMemcpyHostToDevice, gpu_stream[d]));
-        compute_leaves_hashes<<<leaves_cnt / TPB + 1, TPB, 0, gpu_stream[d]>>>(gpu_leaves[d], leaves_cnt, leaf_size, gpu_digests[d], gpu_indexes[d], d * lea);
-    }
-
-    int r = global_max_round;
-    for (; global_round_size[r] > TPB; r--)
-    {
-        compute_internal_hashes_per_round<<<global_round_size[r] / TPB, TPB>>>(gpu_digests, global_round_size[r], r, global_max_round_size, gpu_internal_indexes);
-    }
-
-    for (; r > 0; r--)
-    {
-        compute_internal_hashes_per_round<<<1, global_round_size[r]>>>(gpu_digests, global_round_size[r], r, global_max_round_size, gpu_internal_indexes);
-    }
-
-    CHECKCUDAERR(cudaMemcpyAsync(global_digests_buf, gpu_digests, digests_size_bytes, cudaMemcpyDeviceToHost));
-
-    compute_caps_hashes_per_round<<<1, global_round_size[0]>>>(gpu_caps, gpu_digests, global_round_size[0], 0, global_max_round_size, gpu_internal_indexes);
-
-    CHECKCUDAERR(cudaMemcpy(global_cap_buf, gpu_caps, caps_size_bytes, cudaMemcpyDeviceToHost));
-
-    // free
-    cudaFree(gpu_digests);
-    cudaFree(gpu_caps);
-    cudaFree(gpu_indexes);
-    cudaFree(gpu_leaves);
-    cudaFree(gpu_internal_indexes);
-    cudaFree(gpu_round_size);
-}
-*/
-
-void fill_digests_buf_linear_gpu(
-    u64 digests_buf_size,
-    u64 cap_buf_size,
-    u64 leaves_buf_size,
-    u64 leaf_size,
-    u64 cap_height)
-{
-    // 1. copy leaves from CPU to GPU
-    // 2. compute leaf hashes on GPU
-    // 3. compute internal hashes on GPU
-    // 4. copy data from GPU to CPU
-    // 5. internal hashes on CPU
-    // 6. compute cap hashes on CPU
-
-    u64 *gpu_leaves;
-    u64 *gpu_digests;
-
-    // 1. copy leaves from CPU to GPU
-    u64 leaves_size_bytes = leaves_buf_size * leaf_size * 8;
-    CHECKCUDAERR(cudaMalloc(&gpu_leaves, leaves_size_bytes));
-    CHECKCUDAERR(cudaMemcpyAsync(gpu_leaves, global_leaves_buf, leaves_size_bytes, cudaMemcpyHostToDevice));
-
-    // 2.1. (special case) compute leaf hashes on GPU
-    if (cap_buf_size == leaves_buf_size)
-    {
-        u64 digests_size_bytes = cap_buf_size * HASH_SIZE_U64 * sizeof(u64);
-        CHECKCUDAERR(cudaMalloc(&gpu_digests, digests_size_bytes));
-        compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>(gpu_leaves, leaves_buf_size, leaf_size, gpu_digests);
-        CHECKCUDAERR(cudaMemcpy(global_cap_buf, gpu_digests, digests_size_bytes, cudaMemcpyDeviceToHost));
-
-        // free
-        cudaFree(gpu_digests);
-        cudaFree(gpu_leaves);
-
-        return;
-    }
-
-    // 2. compute leaf hashes on GPU
-    u64 subtree_digests_len = digests_buf_size >> cap_height;
-    u64 subtree_leaves_len = leaves_buf_size >> cap_height;
-    u64 digests_chunks = digests_buf_size / subtree_digests_len;
-    u64 leaves_chunks = leaves_buf_size / subtree_leaves_len;
-    assert(digests_chunks == cap_buf_size);
-    assert(digests_chunks == leaves_chunks);
-
-    u64 digests_size_bytes = digests_buf_size * HASH_SIZE_U64 * sizeof(u64);
-    CHECKCUDAERR(cudaMalloc(&gpu_digests, digests_size_bytes));
-
-    // 2.2. (special cases) compute leaf hashes on CPU
-    if (subtree_leaves_len <= 2)
-    {
-        // for all the subtrees
-#pragma omp parallel for
-        for (u64 k = 0; k < cap_buf_size; k++)
-        {
-            // printf("Subtree %d\n", k);
-            u64 *leaves_buf_ptr = global_leaves_buf + k * subtree_leaves_len * leaf_size;
-            u64 *digests_buf_ptr = global_digests_buf + k * subtree_digests_len * HASH_SIZE_U64;
-            u64 *cap_buf_ptr = global_cap_buf + k * HASH_SIZE_U64;
-
-            // if one leaf => return its hash
-            if (subtree_leaves_len == 1)
-            {
-                cpu_hash_one_ptr(leaves_buf_ptr, leaf_size, digests_buf_ptr);
-                memcpy(cap_buf_ptr, digests_buf_ptr, HASH_SIZE);
-            }
-            else
-            {
-                // if two leaves => return their concat hash
-                if (subtree_leaves_len == 2)
-                {
-                    cpu_hash_one_ptr(leaves_buf_ptr, leaf_size, digests_buf_ptr);
-                    cpu_hash_one_ptr(leaves_buf_ptr + leaf_size, leaf_size, digests_buf_ptr + HASH_SIZE_U64);
-                    cpu_hash_two_ptr(digests_buf_ptr, digests_buf_ptr + HASH_SIZE_U64, cap_buf_ptr);
-                }
-            }
-        }
-        // free
-        cudaFree(gpu_digests);
-        cudaFree(gpu_leaves);
-        return;
-    }
-
-    // 2.3. (general case) compute leaf hashes on GPU
-    compute_leaves_hashes_linear_all<<<leaves_buf_size / TPB + 1, TPB>>>(gpu_leaves, leaves_buf_size, leaf_size, gpu_digests, subtree_leaves_len, subtree_digests_len);
-
-    // 3. compute internal hashes on GPU
-    u64 r = (u64)log2(subtree_leaves_len) - 1;
-    u64 last_index = subtree_digests_len - subtree_leaves_len;
-
-    for (; (1 << r) * cap_buf_size > TPB; r--)
-    {
-        // printf("GPU Round %u\n", r);
-        last_index -= (1 << r);
-        compute_internal_hashes_linear_all<<<((1 << r) * cap_buf_size) / TPB + 1, TPB>>>(gpu_digests, (1 << r), last_index, cap_buf_size, subtree_digests_len);
-    }
-
-    for (; r > 0; r--)
-    {
-        // printf("GPU Round %u\n", r);
-        last_index -= (1 << r);
-        compute_internal_hashes_linear_all<<<1, (1 << r) * cap_buf_size>>>(gpu_digests, (1 << r), last_index, cap_buf_size, subtree_digests_len);
-    }
-
-    // 4. copy data from GPU to CPU
-    CHECKCUDAERR(cudaMemcpyAsync(global_digests_buf, gpu_digests, digests_buf_size * HASH_SIZE, cudaMemcpyDeviceToHost));
-
-    // 5. compute cap hashes on GPU (we reuse gpu_leaves buffer)
-    if (cap_buf_size <= TPB)
-    {
-        compute_caps_hashes_linear<<<1, cap_buf_size>>>(gpu_leaves, gpu_digests, cap_buf_size, subtree_digests_len);
-    }
-    else
-    {
-        compute_caps_hashes_linear<<<cap_buf_size / TPB + 1, TPB>>>(gpu_leaves, gpu_digests, cap_buf_size, subtree_digests_len);
-    }
-
-    // 6. copy data from GPU to CPU (we reuse gpu_leaves buffer)
-    CHECKCUDAERR(cudaMemcpy(global_cap_buf, gpu_leaves, cap_buf_size * HASH_SIZE, cudaMemcpyDeviceToHost));
-
-    // free
-    cudaFree(gpu_digests);
-    cudaFree(gpu_leaves);
+    gpu_hash_two((gl64_t *)sptr1, (gl64_t *)(sptr1 + HASH_SIZE_U64), (gl64_t *)dptr, hash_type);
 }
 
 void fill_digests_buf_linear_gpu_with_gpu_ptr(
@@ -848,17 +196,15 @@ void fill_digests_buf_linear_gpu_with_gpu_ptr(
     uint64_t leaves_buf_size,
     uint64_t leaf_size,
     uint64_t cap_height,
-    uint64_t hash_type)
+    uint64_t hash_type,
+    uint64_t gpu_id)
 {
-    init_gpu_functions(hash_type, 0);
-
-    // TODO: take gpu_id as param
-    CHECKCUDAERR(cudaSetDevice(0));
+    CHECKCUDAERR(cudaSetDevice(gpu_id));
 
     // (special case) compute leaf hashes on GPU
     if (cap_buf_size == leaves_buf_size)
     {
-        compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)cap_buf_gpu_ptr);
+        compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)cap_buf_gpu_ptr, hash_type);
         return;
     }
 
@@ -875,25 +221,25 @@ void fill_digests_buf_linear_gpu_with_gpu_ptr(
     {
         if (subtree_leaves_len == 1)
         {
-            compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)cap_buf_gpu_ptr);
+            compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)cap_buf_gpu_ptr, hash_type);
         }
         else
         {
-            compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)digests_buf_gpu_ptr);
+            compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)digests_buf_gpu_ptr, hash_type);
             if (cap_buf_size <= TPB)
             {
-                compute_caps_hashes_linear<<<1, cap_buf_size>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
+                compute_caps_hashes_linear<<<1, cap_buf_size>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len, hash_type);
             }
             else
             {
-                compute_caps_hashes_linear<<<cap_buf_size / TPB + 1, TPB>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
+                compute_caps_hashes_linear<<<cap_buf_size / TPB + 1, TPB>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len, hash_type);
             }
         }
         return;
     }
 
     // (general case) compute leaf hashes on GPU
-    compute_leaves_hashes_linear_all<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)digests_buf_gpu_ptr, subtree_leaves_len, subtree_digests_len);
+    compute_leaves_hashes_linear_all<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)digests_buf_gpu_ptr, subtree_leaves_len, subtree_digests_len, hash_type);
 
     // compute internal hashes on GPU
     u64 r = (u64)log2(subtree_leaves_len) - 1;
@@ -903,24 +249,24 @@ void fill_digests_buf_linear_gpu_with_gpu_ptr(
     {
         // printf("GPU Round %u\n", r);
         last_index -= (1 << r);
-        compute_internal_hashes_linear_all<<<((1 << r) * cap_buf_size) / TPB + 1, TPB>>>((u64 *)digests_buf_gpu_ptr, (1 << r), last_index, cap_buf_size, subtree_digests_len);
+        compute_internal_hashes_linear_all<<<((1 << r) * cap_buf_size) / TPB + 1, TPB>>>((u64 *)digests_buf_gpu_ptr, (1 << r), last_index, cap_buf_size, subtree_digests_len, hash_type);
     }
 
     for (; r > 0; r--)
     {
         // printf("GPU Round %u\n", r);
         last_index -= (1 << r);
-        compute_internal_hashes_linear_all<<<1, (1 << r) * cap_buf_size>>>((u64 *)digests_buf_gpu_ptr, (1 << r), last_index, cap_buf_size, subtree_digests_len);
+        compute_internal_hashes_linear_all<<<1, (1 << r) * cap_buf_size>>>((u64 *)digests_buf_gpu_ptr, (1 << r), last_index, cap_buf_size, subtree_digests_len, hash_type);
     }
 
     // compute cap hashes on GPU
     if (cap_buf_size <= TPB)
     {
-        compute_caps_hashes_linear<<<1, cap_buf_size>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
+        compute_caps_hashes_linear<<<1, cap_buf_size>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len, hash_type);
     }
     else
     {
-        compute_caps_hashes_linear<<<cap_buf_size / TPB + 1, TPB>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
+        compute_caps_hashes_linear<<<cap_buf_size / TPB + 1, TPB>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len, hash_type);
     }
 }
 
@@ -936,8 +282,6 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr(
     uint64_t cap_height,
     uint64_t hash_type)
 {
-    init_gpu_functions(hash_type);
-
     int nDevices = 0;
     CHECKCUDAERR(cudaGetDeviceCount(&nDevices));
 
@@ -963,14 +307,14 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr(
             CHECKCUDAERR(cudaSetDevice(i));
             CHECKCUDAERR(cudaStreamCreate(gpu_stream + i));
             CHECKCUDAERR(cudaMalloc(&gpu_leaves_ptrs[i], leaves_size_bytes));
-            CHECKCUDAERR(cudaMemcpyPeerAsync(gpu_leaves_ptrs[i], i, (u64*)leaves_buf_gpu_ptr + leaves_per_gpu, 0, leaves_size_bytes, gpu_stream[i]));
+            CHECKCUDAERR(cudaMemcpyPeerAsync(gpu_leaves_ptrs[i], i, (u64 *)leaves_buf_gpu_ptr + leaves_per_gpu, 0, leaves_size_bytes, gpu_stream[i]));
             CHECKCUDAERR(cudaMalloc(&gpu_caps_ptrs[i], caps_per_gpu * HASH_SIZE_U64 * sizeof(u64)));
         }
 #pragma omp parallel for num_threads(nDevices)
         for (int i = 0; i < nDevices; i++)
         {
             CHECKCUDAERR(cudaSetDevice(i));
-            compute_leaves_hashes_direct<<<leaves_buf_size / (nDevices * TPB) + 1, TPB>>>(gpu_leaves_ptrs[i], leaves_buf_size / nDevices, leaf_size, gpu_caps_ptrs[i]);
+            compute_leaves_hashes_direct<<<leaves_buf_size / (nDevices * TPB) + 1, TPB>>>(gpu_leaves_ptrs[i], leaves_buf_size / nDevices, leaf_size, gpu_caps_ptrs[i], hash_type);
         }
 #pragma omp parallel for num_threads(nDevices)
         for (int i = 1; i < nDevices; i++)
@@ -1008,18 +352,18 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr(
         CHECKCUDAERR(cudaSetDevice(0));
         if (subtree_leaves_len == 1)
         {
-            compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)cap_buf_gpu_ptr);
+            compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)cap_buf_gpu_ptr, hash_type);
         }
         else
         {
-            compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)digests_buf_gpu_ptr);
+            compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)digests_buf_gpu_ptr, hash_type);
             if (cap_buf_size <= TPB)
             {
-                compute_caps_hashes_linear<<<1, cap_buf_size>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
+                compute_caps_hashes_linear<<<1, cap_buf_size>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len, hash_type);
             }
             else
             {
-                compute_caps_hashes_linear<<<cap_buf_size / TPB + 1, TPB>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
+                compute_caps_hashes_linear<<<cap_buf_size / TPB + 1, TPB>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len, hash_type);
             }
         }
         return;
@@ -1030,7 +374,7 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr(
     {
         nDevices = (1 << cap_height);
     }
-    
+
     u64 leaves_per_gpu = subtree_leaves_len;
     u64 leaves_size_bytes = leaves_per_gpu * leaf_size * sizeof(u64);
     u64 digests_per_gpu = subtree_digests_len;
@@ -1041,7 +385,7 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr(
     {
         CHECKCUDAERR(cudaSetDevice(i));
         CHECKCUDAERR(cudaStreamCreate(gpu_stream + i));
-        CHECKCUDAERR(cudaMalloc(&gpu_leaves_ptrs[i], leaves_size_bytes));        
+        CHECKCUDAERR(cudaMalloc(&gpu_leaves_ptrs[i], leaves_size_bytes));
         CHECKCUDAERR(cudaMalloc(&gpu_digests_ptrs[i], digests_size_bytes));
     }
 
@@ -1050,7 +394,7 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr(
 #pragma omp parallel for num_threads(nDevices)
         for (int i = 0; i < nDevices; i++)
         {
-            CHECKCUDAERR(cudaMemcpyPeerAsync(gpu_leaves_ptrs[i], i, (u64*)leaves_buf_gpu_ptr + (k + i) * leaves_per_gpu * leaf_size, 0, leaves_size_bytes, gpu_stream[i]));
+            CHECKCUDAERR(cudaMemcpyPeerAsync(gpu_leaves_ptrs[i], i, (u64 *)leaves_buf_gpu_ptr + (k + i) * leaves_per_gpu * leaf_size, 0, leaves_size_bytes, gpu_stream[i]));
         }
 #pragma omp parallel for num_threads(nDevices)
         for (int i = 0; i < nDevices; i++)
@@ -1059,7 +403,7 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr(
 
             int blocks = (subtree_leaves_len % TPB == 0) ? subtree_leaves_len / TPB : subtree_leaves_len / TPB + 1;
             int threads = (subtree_leaves_len < TPB) ? subtree_leaves_len : TPB;
-            compute_leaves_hashes_linear_per_gpu<<<blocks, threads, 0, gpu_stream[i]>>>(gpu_leaves_ptrs[i], leaf_size, gpu_digests_ptrs[i], subtree_leaves_len, subtree_digests_len);
+            compute_leaves_hashes_linear_per_gpu<<<blocks, threads, 0, gpu_stream[i]>>>(gpu_leaves_ptrs[i], leaf_size, gpu_digests_ptrs[i], subtree_leaves_len, subtree_digests_len, hash_type);
 
             u64 r = (u64)log2(subtree_leaves_len) - 1;
             u64 last_index = subtree_digests_len - subtree_leaves_len;
@@ -1067,14 +411,14 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr(
             for (; (1 << r) > TPB; r--)
             {
                 last_index -= (1 << r);
-                compute_internal_hashes_linear_per_gpu<<<(1 << r) / TPB + 1, TPB, 0, gpu_stream[i]>>>(gpu_digests_ptrs[i], (1 << r), last_index);
+                compute_internal_hashes_linear_per_gpu<<<(1 << r) / TPB + 1, TPB, 0, gpu_stream[i]>>>(gpu_digests_ptrs[i], (1 << r), last_index, hash_type);
             }
             for (; r > 0; r--)
             {
                 last_index -= (1 << r);
-                compute_internal_hashes_linear_per_gpu<<<1, (1 << r), 0, gpu_stream[i]>>>(gpu_digests_ptrs[i], (1 << r), last_index);
+                compute_internal_hashes_linear_per_gpu<<<1, (1 << r), 0, gpu_stream[i]>>>(gpu_digests_ptrs[i], (1 << r), last_index, hash_type);
             }
-            CHECKCUDAERR(cudaMemcpyPeerAsync((u64*)digests_buf_gpu_ptr + (k + i) * subtree_digests_len * HASH_SIZE_U64, 0, gpu_digests_ptrs[i], i, digests_size_bytes, gpu_stream[i]));
+            CHECKCUDAERR(cudaMemcpyPeerAsync((u64 *)digests_buf_gpu_ptr + (k + i) * subtree_digests_len * HASH_SIZE_U64, 0, gpu_digests_ptrs[i], i, digests_size_bytes, gpu_stream[i]));
         }
 #pragma omp parallel for num_threads(nDevices)
         for (int i = 0; i < nDevices; i++)
@@ -1088,11 +432,11 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr(
     CHECKCUDAERR(cudaSetDevice(0));
     if (cap_buf_size <= TPB)
     {
-        compute_caps_hashes_linear<<<1, cap_buf_size>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
+        compute_caps_hashes_linear<<<1, cap_buf_size>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len, hash_type);
     }
     else
     {
-        compute_caps_hashes_linear<<<cap_buf_size / TPB + 1, TPB>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
+        compute_caps_hashes_linear<<<cap_buf_size / TPB + 1, TPB>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len, hash_type);
     }
 
 #pragma omp parallel for num_threads(nDevices)
@@ -1103,359 +447,6 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr(
         CHECKCUDAERR(cudaFree(gpu_leaves_ptrs[i]));
         CHECKCUDAERR(cudaFree(gpu_digests_ptrs[i]));
     }
-}
-
-void fill_digests_buf_linear_gpu_v1(
-    u64 digests_buf_size,
-    u64 cap_buf_size,
-    u64 leaves_buf_size,
-    u64 leaf_size,
-    u64 cap_height)
-{
-    u64 *gpu_leaves;
-    u64 *gpu_digests;
-
-    u64 leaves_size_bytes = leaves_buf_size * leaf_size * 8;
-    CHECKCUDAERR(cudaMalloc(&gpu_leaves, leaves_size_bytes));
-    CHECKCUDAERR(cudaMemcpyAsync(gpu_leaves, global_leaves_buf, leaves_size_bytes, cudaMemcpyHostToDevice));
-
-    if (cap_buf_size == leaves_buf_size)
-    {
-        u64 digests_size_bytes = cap_buf_size * HASH_SIZE_U64 * sizeof(u64);
-        CHECKCUDAERR(cudaMalloc(&gpu_digests, digests_size_bytes));
-        compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>(gpu_leaves, leaves_buf_size, leaf_size, gpu_digests);
-        CHECKCUDAERR(cudaMemcpy(global_cap_buf, gpu_digests, digests_size_bytes, cudaMemcpyDeviceToHost));
-
-        // free
-        cudaFree(gpu_digests);
-        cudaFree(gpu_leaves);
-
-        return;
-    }
-
-    // 1. copy leaves from CPU to GPU
-    // 2. compute leaf hashes on GPU
-    // 3. compute internal hashes on GPU
-    // 4. copy data from GPU to CPU
-    // 5. internal hashes on CPU
-    // 6. compute cap hashes on CPU
-
-    u64 subtree_digests_len = digests_buf_size >> cap_height;
-    u64 subtree_leaves_len = leaves_buf_size >> cap_height;
-    u64 digests_chunks = digests_buf_size / subtree_digests_len;
-    u64 leaves_chunks = leaves_buf_size / subtree_leaves_len;
-    assert(digests_chunks == cap_buf_size);
-    assert(digests_chunks == leaves_chunks);
-
-    u64 digests_size_bytes = digests_buf_size * HASH_SIZE_U64 * sizeof(u64);
-    CHECKCUDAERR(cudaMalloc(&gpu_digests, digests_size_bytes));
-
-    // for all the subtrees
-    for (u64 k = 0; k < cap_buf_size; k++)
-    {
-        // printf("Subtree %d, Leaves %lu, Digests %lu\n", k, subtree_leaves_len, subtree_digests_len);
-        u64 *leaves_buf_ptr = global_leaves_buf + k * subtree_leaves_len * leaf_size;
-        u64 *digests_buf_ptr = global_digests_buf + k * subtree_digests_len * HASH_SIZE_U64;
-        u64 *cap_buf_ptr = global_cap_buf + k * HASH_SIZE_U64;
-
-        // if one leaf => return it hash
-        if (subtree_leaves_len == 1)
-        {
-            cpu_hash_one_ptr(leaves_buf_ptr, leaf_size, digests_buf_ptr);
-            memcpy(cap_buf_ptr, digests_buf_ptr, HASH_SIZE);
-            continue;
-        }
-        // if two leaves => return their concat hash
-        if (subtree_leaves_len == 2)
-        {
-            cpu_hash_one_ptr(leaves_buf_ptr, leaf_size, digests_buf_ptr);
-            cpu_hash_one_ptr(leaves_buf_ptr + leaf_size, leaf_size, digests_buf_ptr + HASH_SIZE_U64);
-            cpu_hash_two_ptr(digests_buf_ptr, digests_buf_ptr + HASH_SIZE_U64, cap_buf_ptr);
-            continue;
-        }
-
-        // 2. compute leaf hashes on GPU
-        u64 *gpu_digests_chunk_ptr = gpu_digests + k * subtree_digests_len * HASH_SIZE_U64;
-        u64 *gpu_digests_curr_ptr = gpu_digests_chunk_ptr + (subtree_digests_len - subtree_leaves_len) * HASH_SIZE_U64;
-        u64 *gpu_leaves_chunk_ptr = gpu_leaves + k * subtree_leaves_len * leaf_size;
-        compute_leaves_hashes_direct<<<subtree_leaves_len / TPB + 1, TPB>>>(gpu_leaves_chunk_ptr, subtree_leaves_len, leaf_size, gpu_digests_curr_ptr);
-
-        // 3. compute internal hashes on GPU
-        u64 r = (u64)log2(subtree_leaves_len) - 1;
-        u64 last_index = subtree_digests_len - subtree_leaves_len;
-
-        for (; (1 << r) > TPB; r--)
-        {
-            last_index -= (1 << r);
-            // printf("GPU round %d\n", r);
-            gpu_digests_curr_ptr = gpu_digests_chunk_ptr + last_index * HASH_SIZE_U64;
-            compute_internal_hashes_linear<<<(1 << r) / TPB + 1, TPB>>>(gpu_digests_curr_ptr, (1 << r), last_index);
-        }
-
-        // 4. copy data from GPU to CPU
-        CHECKCUDAERR(cudaMemcpy(digests_buf_ptr, gpu_digests_chunk_ptr, subtree_digests_len * HASH_SIZE, cudaMemcpyDeviceToHost));
-
-        // 5. internal hashes on CPU
-        for (; r > 0; r--)
-        {
-            last_index -= (1 << r);
-            // printf("CPU round %d Last idx %d\n", r, last_index);
-            u64 *digests_buf_ptr2 = digests_buf_ptr + last_index * HASH_SIZE_U64;
-            for (int idx = 0; idx < (1 << r); idx++)
-            {
-                u64 left_idx = 2 * (idx + 1) + last_index;
-                u64 right_idx = left_idx + 1;
-                u64 *left_ptr = digests_buf_ptr2 + (left_idx * HASH_SIZE_U64);
-                u64 *right_ptr = digests_buf_ptr2 + (right_idx * HASH_SIZE_U64);
-                // printf("%lu %lu\n", *left_ptr, *right_ptr);
-                cpu_hash_two_ptr(left_ptr, right_ptr, digests_buf_ptr2 + (idx * HASH_SIZE_U64));
-            }
-        }
-
-        // 6. compute cap hashes on CPU
-        cpu_hash_two_ptr(digests_buf_ptr, digests_buf_ptr + HASH_SIZE_U64, cap_buf_ptr);
-
-    } // end for k
-
-    // free
-    cudaFree(gpu_digests);
-    cudaFree(gpu_leaves);
-}
-
-void fill_digests_buf_linear_multigpu(
-    uint64_t digests_buf_size,
-    uint64_t cap_buf_size,
-    uint64_t leaves_buf_size,
-    uint64_t leaf_size,
-    uint64_t cap_height,
-    uint64_t ngpus)
-{
-    u64 *gpu_leaves[16];
-    u64 *gpu_digests[16];
-    cudaStream_t gpu_stream[16];
-
-    int nDevices = 0;
-    CHECKCUDAERR(cudaGetDeviceCount(&nDevices));
-    assert(ngpus <= nDevices);
-    assert(ngpus <= 16);
-
-    // (special case) compute leaf hashes on GPU
-    if (cap_buf_size == leaves_buf_size)
-    {
-        u64 leaves_per_gpu;
-        u64 leaves_last_gpu;
-        compute_size_per_gpu(leaves_buf_size, ngpus, &leaves_per_gpu, &leaves_last_gpu);
-
-#pragma omp parallel for num_threads(ngpus)
-        for (int d = 0; d < ngpus; d++)
-        {
-            u64 leaves_cnt = (d == ngpus - 1) ? leaves_last_gpu : leaves_per_gpu;
-            u64 sz = leaves_cnt * sizeof(u64);
-            u64 digests_size_bytes = leaves_cnt * HASH_SIZE_U64 * sizeof(u64);
-            CHECKCUDAERR(cudaSetDevice(d));
-            CHECKCUDAERR(cudaStreamCreate(gpu_stream + d));
-            CHECKCUDAERR(cudaMalloc(&gpu_leaves[d], sz));
-            CHECKCUDAERR(cudaMalloc(&gpu_digests[d], digests_size_bytes));
-            CHECKCUDAERR(cudaMemcpyAsync(gpu_leaves[d], global_leaves_buf + d * leaves_cnt, sz, cudaMemcpyHostToDevice, gpu_stream[d]));
-            compute_leaves_hashes_direct<<<leaves_cnt / TPB + 1, TPB, 0, gpu_stream[d]>>>(gpu_leaves[d], leaves_cnt, leaf_size, gpu_digests[d]);
-            CHECKCUDAERR(cudaMemcpyAsync(global_cap_buf + d * leaves_cnt * HASH_SIZE, gpu_digests[d], digests_size_bytes, cudaMemcpyDeviceToHost, gpu_stream[d]));
-        }
-        for (int d = 0; d < ngpus; d++)
-        {
-            CHECKCUDAERR(cudaSetDevice(d));
-            CHECKCUDAERR(cudaStreamSynchronize(gpu_stream[d]));
-            cudaFree(gpu_digests[d]);
-            cudaFree(gpu_leaves[d]);
-            CHECKCUDAERR(cudaStreamDestroy(gpu_stream[d]));
-        }
-        return;
-    }
-
-    // 2. compute leaf hashes on GPU
-    u64 subtree_digests_len = digests_buf_size >> cap_height;
-    u64 subtree_leaves_len = leaves_buf_size >> cap_height;
-    u64 digests_chunks = digests_buf_size / subtree_digests_len;
-    u64 leaves_chunks = leaves_buf_size / subtree_leaves_len;
-    assert(digests_chunks == cap_buf_size);
-    assert(digests_chunks == leaves_chunks);
-
-    // (special cases) compute leaf hashes on CPU
-    if (subtree_leaves_len <= 2)
-    {
-        // for all the subtrees
-#pragma omp parallel for
-        for (u64 k = 0; k < cap_buf_size; k++)
-        {
-            // printf("Subtree %d\n", k);
-            u64 *leaves_buf_ptr = global_leaves_buf + k * subtree_leaves_len * leaf_size;
-            u64 *digests_buf_ptr = global_digests_buf + k * subtree_digests_len * HASH_SIZE_U64;
-            u64 *cap_buf_ptr = global_cap_buf + k * HASH_SIZE_U64;
-
-            // if one leaf => return it hash
-            if (subtree_leaves_len == 1)
-            {
-                cpu_hash_one_ptr(leaves_buf_ptr, leaf_size, digests_buf_ptr);
-                memcpy(cap_buf_ptr, digests_buf_ptr, HASH_SIZE);
-            }
-            else
-            {
-                // if two leaves => return their concat hash
-                if (subtree_leaves_len == 2)
-                {
-                    cpu_hash_one_ptr(leaves_buf_ptr, leaf_size, digests_buf_ptr);
-                    cpu_hash_one_ptr(leaves_buf_ptr + leaf_size, leaf_size, digests_buf_ptr + HASH_SIZE_U64);
-                    cpu_hash_two_ptr(digests_buf_ptr, digests_buf_ptr + HASH_SIZE_U64, cap_buf_ptr);
-                }
-            }
-        }
-        return;
-    }
-
-    // we compute one sub-tree on each GPU
-    for (int d = 0; d < ngpus; d++)
-    {
-        u64 leaves_size_bytes = subtree_leaves_len * leaf_size * sizeof(u64);
-        u64 digests_size_bytes = subtree_digests_len * HASH_SIZE_U64 * sizeof(u64);
-        CHECKCUDAERR(cudaSetDevice(d));
-        CHECKCUDAERR(cudaStreamCreate(gpu_stream + d));
-        CHECKCUDAERR(cudaMalloc(&(gpu_leaves[d]), leaves_size_bytes));
-        CHECKCUDAERR(cudaMalloc(&(gpu_digests[d]), digests_size_bytes));
-    }
-
-    for (int k = 0; k < cap_buf_size; k += ngpus)
-    {
-#pragma omp parallel for num_threads(ngpus)
-        for (int d = 0; d < ngpus; d++)
-        {
-            if (k + d >= cap_buf_size)
-            {
-                continue;
-            }
-
-            u64 leaves_size_bytes = subtree_leaves_len * leaf_size * sizeof(u64);
-            u64 digests_size_bytes = subtree_digests_len * HASH_SIZE_U64 * sizeof(u64);
-
-            CHECKCUDAERR(cudaSetDevice(d));
-            CHECKCUDAERR(cudaMemcpyAsync(gpu_leaves[d], global_leaves_buf + (k + d) * subtree_leaves_len * leaf_size, leaves_size_bytes, cudaMemcpyHostToDevice, gpu_stream[d]));
-
-            int blocks = (subtree_leaves_len % TPB == 0) ? subtree_leaves_len / TPB : subtree_leaves_len / TPB + 1;
-            int threads = (subtree_leaves_len < TPB) ? subtree_leaves_len : TPB;
-            compute_leaves_hashes_linear_per_gpu<<<blocks, threads, 0, gpu_stream[d]>>>(gpu_leaves[d], leaf_size, gpu_digests[d], subtree_leaves_len, subtree_digests_len);
-
-            u64 r = (u64)log2(subtree_leaves_len) - 1;
-            u64 last_index = subtree_digests_len - subtree_leaves_len;
-
-            for (; (1 << r) > TPB; r--)
-            {
-                last_index -= (1 << r);
-                compute_internal_hashes_linear_per_gpu<<<(1 << r) / TPB + 1, TPB, 0, gpu_stream[d]>>>(gpu_digests[d], (1 << r), last_index);
-            }
-            for (; r > 0; r--)
-            {
-                last_index -= (1 << r);
-                compute_internal_hashes_linear_per_gpu<<<1, (1 << r), 0, gpu_stream[d]>>>(gpu_digests[d], (1 << r), last_index);
-            }
-            CHECKCUDAERR(cudaMemcpyAsync(global_digests_buf + (k + d) * subtree_digests_len * HASH_SIZE_U64, gpu_digests[d], digests_size_bytes, cudaMemcpyDeviceToHost, gpu_stream[d]));
-        }
-        // sync
-        for (int d = 0; d < ngpus; d++)
-        {
-            CHECKCUDAERR(cudaSetDevice(d));
-            CHECKCUDAERR(cudaStreamSynchronize(gpu_stream[d]));
-        }
-    }
-
-    // compute cap hashes on CPU
-#pragma omp parallel for
-    for (int k = 0; k < cap_buf_size; k++)
-    {
-        u64 *digests_buf_ptr = global_digests_buf + k * subtree_digests_len * HASH_SIZE_U64;
-        u64 *cap_buf_ptr = global_cap_buf + k * HASH_SIZE_U64;
-        cpu_hash_two_ptr(digests_buf_ptr, digests_buf_ptr + HASH_SIZE_U64, cap_buf_ptr);
-    }
-
-    // free
-    for (int d = 0; d < ngpus; d++)
-    {
-        cudaFree(gpu_digests[d]);
-        cudaFree(gpu_leaves[d]);
-        CHECKCUDAERR(cudaStreamDestroy(gpu_stream[d]));
-    }
-}
-
-void fill_digests_buf_in_rounds_in_c_on_gpu_with_gpu_ptr(
-    void *digests_buf_gpu_ptr,
-    void *cap_buf_gpu_ptr,
-    void *leaves_buf_gpu_ptr,
-    uint64_t digests_buf_size,
-    uint64_t cap_buf_size,
-    uint64_t leaves_buf_size,
-    uint64_t leaf_size,
-    uint64_t cap_height,
-    uint64_t hash_type)
-{
-    init_gpu_functions(hash_type);
-    fill_init_rounds(leaves_buf_size, log2(leaves_buf_size) + 1);
-
-    if (cap_buf_size == leaves_buf_size)
-    {
-        compute_leaves_hashes_direct<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)cap_buf_gpu_ptr);
-        return;
-    }
-
-    // 1. run fill_tree_get_index on CPU
-    // 2.1 compute leaf hashes on GPU
-    // 2.2 (in parallel) copy task index data to GPU
-    // 3. compute internal hashes on GPU
-    // 4. compute cap hashes on GPU
-
-    u64 subtree_digests_len = digests_buf_size >> cap_height;
-    u64 subtree_leaves_len = leaves_buf_size >> cap_height;
-    u64 digests_chunks = digests_buf_size / subtree_digests_len;
-    u64 leaves_chunks = leaves_buf_size / subtree_leaves_len;
-    assert(digests_chunks == cap_buf_size);
-    assert(digests_chunks == leaves_chunks);
-
-    // 1. run fill_tree_get_index on CPU
-    for (u64 k = 0; k < cap_buf_size; k++)
-    {
-        fill_subtree_get_index(k, k * subtree_digests_len, subtree_digests_len, k * subtree_leaves_len, subtree_leaves_len, leaf_size, 0);
-    }
-
-    u32 *gpu_indexes;
-    u32 *gpu_round_size;
-    HashTask *gpu_internal_indexes;
-
-    CHECKCUDAERR(cudaMalloc(&gpu_indexes, leaves_buf_size * sizeof(u32)));
-    CHECKCUDAERR(cudaMalloc(&gpu_internal_indexes, (global_max_round + 1) * global_max_round_size * sizeof(HashTask)));
-    CHECKCUDAERR(cudaMalloc(&gpu_round_size, (global_max_round + 1) * sizeof(u32)));
-
-    // 2.1 and 2.2
-    CHECKCUDAERR(cudaMemcpyAsync(gpu_indexes, global_leaf_index, leaves_buf_size * sizeof(u32), cudaMemcpyHostToDevice));
-    CHECKCUDAERR(cudaMemcpyAsync(gpu_round_size, global_round_size, (global_max_round + 1) * sizeof(u32), cudaMemcpyHostToDevice));
-    CHECKCUDAERR(cudaMemcpyAsync((void *)gpu_internal_indexes, (void *)global_internal_index, (global_max_round + 1) * global_max_round_size * sizeof(HashTask), cudaMemcpyHostToDevice));
-    compute_leaves_hashes<<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)digests_buf_gpu_ptr, gpu_indexes);
-
-    // 3.
-    int r = global_max_round;
-    for (; global_round_size[r] > TPB; r--)
-    {
-        compute_internal_hashes_per_round<<<global_round_size[r] / TPB, TPB>>>((u64 *)digests_buf_gpu_ptr, global_round_size[r], r, global_max_round_size, gpu_internal_indexes);
-    }
-    for (; r > 0; r--)
-    {
-        compute_internal_hashes_per_round<<<1, global_round_size[r]>>>((u64 *)digests_buf_gpu_ptr, global_round_size[r], r, global_max_round_size, gpu_internal_indexes);
-    }
-
-    // 4.
-    compute_caps_hashes_per_round<<<1, global_round_size[0]>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, global_round_size[0], 0, global_max_round_size, gpu_internal_indexes);
-
-    // free
-    cudaFree(gpu_indexes);
-    cudaFree(gpu_internal_indexes);
-    cudaFree(gpu_round_size);
-
-    fill_delete_rounds();
 }
 
 // #define TESTING

--- a/cuda/merkle/merkle.h
+++ b/cuda/merkle/merkle.h
@@ -13,60 +13,7 @@
 #define EXTERNC
 #endif
 
-EXTERNC void fill_digests_buf_in_c(
-    uint64_t digests_buf_size,
-    uint64_t cap_buf_size,
-    uint64_t leaves_buf_size,
-    uint64_t leaf_size,
-    uint64_t cap_height
-);
-
-EXTERNC void fill_digests_buf_in_rounds_in_c(
-    uint64_t digests_buf_size,
-    uint64_t cap_buf_size,
-    uint64_t leaves_buf_size,
-    uint64_t leaf_size,
-    uint64_t cap_height
-);
-
-EXTERNC void fill_digests_buf_in_rounds_in_c_on_gpu(
-    uint64_t digests_buf_size,
-    uint64_t cap_buf_size,
-    uint64_t leaves_buf_size,
-    uint64_t leaf_size,
-    uint64_t cap_height
-);
-
-EXTERNC void fill_digests_buf_in_rounds_in_c_on_gpu_with_gpu_ptr(
-    void *digests_buf_gpu_ptr,
-    void *cap_buf_gpu_ptr,
-    void *leaves_buf_gpu_ptr,
-    uint64_t digests_buf_size,
-    uint64_t cap_buf_size,
-    uint64_t leaves_buf_size,
-    uint64_t leaf_size,
-    uint64_t cap_height,
-    uint64_t hash_type
-);
-
-EXTERNC void fill_digests_buf_linear_cpu(
-    uint64_t digests_buf_size,
-    uint64_t cap_buf_size,
-    uint64_t leaves_buf_size,
-    uint64_t leaf_size,
-    uint64_t cap_height
-);
-
-EXTERNC void fill_digests_buf_linear_gpu(
-    uint64_t digests_buf_size,
-    uint64_t cap_buf_size,
-    uint64_t leaves_buf_size,
-    uint64_t leaf_size,
-    uint64_t cap_height
-);
-
 EXTERNC void fill_digests_buf_linear_gpu_with_gpu_ptr(
-    // int gpu_id,
     void *digests_buf_gpu_ptr,
     void *cap_buf_gpu_ptr,
     void *leaves_buf_gpu_ptr,
@@ -75,16 +22,8 @@ EXTERNC void fill_digests_buf_linear_gpu_with_gpu_ptr(
     uint64_t leaves_buf_size,
     uint64_t leaf_size,
     uint64_t cap_height,
-    uint64_t hash_type
-);
-
-EXTERNC void fill_digests_buf_linear_multigpu(
-    uint64_t digests_buf_size,
-    uint64_t cap_buf_size,
-    uint64_t leaves_buf_size,
-    uint64_t leaf_size,
-    uint64_t cap_height,
-    uint64_t ngpus
+    uint64_t hash_type,
+    uint64_t gpu_id
 );
 
 EXTERNC void fill_digests_buf_linear_multigpu_with_gpu_ptr(
@@ -98,29 +37,5 @@ EXTERNC void fill_digests_buf_linear_multigpu_with_gpu_ptr(
     uint64_t cap_height,
     uint64_t hash_type
 );
-
-EXTERNC void fill_init(
-    uint64_t digests_count,
-    uint64_t leaves_count,
-    uint64_t caps_count,
-    uint64_t leaf_size,
-    uint64_t hash_size,
-    uint64_t hash_type
-);
-
-EXTERNC void fill_init_rounds(
-    uint64_t leaves_count,
-    uint64_t rounds
-);
-
-EXTERNC void fill_delete();
-
-EXTERNC void fill_delete_rounds();
-
-EXTERNC uint64_t* get_digests_ptr();
-
-EXTERNC uint64_t* get_cap_ptr();
-
-EXTERNC uint64_t* get_leaves_ptr();
 
 #endif // __MERKEL_H__

--- a/src/merkle/bindings.rs
+++ b/src/merkle/bindings.rs
@@ -208,64 +208,6 @@ pub type uint_fast64_t = ::std::os::raw::c_ulong;
 pub type intmax_t = __intmax_t;
 pub type uintmax_t = __uintmax_t;
 extern "C" {
-    pub fn fill_digests_buf_in_c(
-        digests_buf_size: u64,
-        cap_buf_size: u64,
-        leaves_buf_size: u64,
-        leaf_size: u64,
-        cap_height: u64,
-    );
-}
-extern "C" {
-    pub fn fill_digests_buf_in_rounds_in_c(
-        digests_buf_size: u64,
-        cap_buf_size: u64,
-        leaves_buf_size: u64,
-        leaf_size: u64,
-        cap_height: u64,
-    );
-}
-extern "C" {
-    pub fn fill_digests_buf_in_rounds_in_c_on_gpu(
-        digests_buf_size: u64,
-        cap_buf_size: u64,
-        leaves_buf_size: u64,
-        leaf_size: u64,
-        cap_height: u64,
-    );
-}
-extern "C" {
-    pub fn fill_digests_buf_in_rounds_in_c_on_gpu_with_gpu_ptr(
-        digests_buf_gpu_ptr: *mut ::std::os::raw::c_void,
-        cap_buf_gpu_ptr: *mut ::std::os::raw::c_void,
-        leaves_buf_gpu_ptr: *mut ::std::os::raw::c_void,
-        digests_buf_size: u64,
-        cap_buf_size: u64,
-        leaves_buf_size: u64,
-        leaf_size: u64,
-        cap_height: u64,
-        hash_type: u64,
-    );
-}
-extern "C" {
-    pub fn fill_digests_buf_linear_cpu(
-        digests_buf_size: u64,
-        cap_buf_size: u64,
-        leaves_buf_size: u64,
-        leaf_size: u64,
-        cap_height: u64,
-    );
-}
-extern "C" {
-    pub fn fill_digests_buf_linear_gpu(
-        digests_buf_size: u64,
-        cap_buf_size: u64,
-        leaves_buf_size: u64,
-        leaf_size: u64,
-        cap_height: u64,
-    );
-}
-extern "C" {
     pub fn fill_digests_buf_linear_gpu_with_gpu_ptr(
         digests_buf_gpu_ptr: *mut ::std::os::raw::c_void,
         cap_buf_gpu_ptr: *mut ::std::os::raw::c_void,
@@ -276,16 +218,7 @@ extern "C" {
         leaf_size: u64,
         cap_height: u64,
         hash_type: u64,
-    );
-}
-extern "C" {
-    pub fn fill_digests_buf_linear_multigpu(
-        digests_buf_size: u64,
-        cap_buf_size: u64,
-        leaves_buf_size: u64,
-        leaf_size: u64,
-        cap_height: u64,
-        ngpus: u64,
+        gpu_id: u64,
     );
 }
 extern "C" {
@@ -300,32 +233,4 @@ extern "C" {
         cap_height: u64,
         hash_type: u64,
     );
-}
-extern "C" {
-    pub fn fill_init(
-        digests_count: u64,
-        leaves_count: u64,
-        caps_count: u64,
-        leaf_size: u64,
-        hash_size: u64,
-        hash_type: u64,
-    );
-}
-extern "C" {
-    pub fn fill_init_rounds(leaves_count: u64, rounds: u64);
-}
-extern "C" {
-    pub fn fill_delete();
-}
-extern "C" {
-    pub fn fill_delete_rounds();
-}
-extern "C" {
-    pub fn get_digests_ptr() -> *mut u64;
-}
-extern "C" {
-    pub fn get_cap_ptr() -> *mut u64;
-}
-extern "C" {
-    pub fn get_leaves_ptr() -> *mut u64;
 }


### PR DESCRIPTION
This (+ the change in Plonky2) seems to improve the TPS of ZKDEX to 7.