### PR TITLE
fix: address critical safety and reliability issues

### DIFF
--- a/native/merkle/merkle.cu
+++ b/native/merkle/merkle.cu
@@ -178,6 +178,7 @@ void fill_digests_buf_linear_gpu_with_gpu_ptr_template(
     if (cap_buf_size == leaves_buf_size)
     {
         compute_leaves_hashes_direct<H><<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)cap_buf_gpu_ptr);
+        CHECKCUDAERR(cudaGetLastError());
         return;
     }
 
@@ -195,10 +196,12 @@ void fill_digests_buf_linear_gpu_with_gpu_ptr_template(
         if (subtree_leaves_len == 1)
         {
             compute_leaves_hashes_direct<H><<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)cap_buf_gpu_ptr);
+            CHECKCUDAERR(cudaGetLastError());
         }
         else
         {
             compute_leaves_hashes_direct<H><<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)digests_buf_gpu_ptr);
+            CHECKCUDAERR(cudaGetLastError());
             if (cap_buf_size <= TPB)
             {
                 compute_caps_hashes_linear<H><<<1, cap_buf_size>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
@@ -207,12 +210,14 @@ void fill_digests_buf_linear_gpu_with_gpu_ptr_template(
             {
                 compute_caps_hashes_linear<H><<<cap_buf_size / TPB + 1, TPB>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
             }
+            CHECKCUDAERR(cudaGetLastError());
         }
         return;
     }
 
     // (general case) compute leaf hashes on GPU
     compute_leaves_hashes_linear_all<H><<<leaves_buf_size / TPB + 1, TPB>>>((u64 *)leaves_buf_gpu_ptr, leaves_buf_size, leaf_size, (u64 *)digests_buf_gpu_ptr, subtree_leaves_len, subtree_digests_len);
+    CHECKCUDAERR(cudaGetLastError());
 
     // compute internal hashes on GPU
     u64 r = (u64)log2(subtree_leaves_len) - 1;
@@ -223,6 +228,7 @@ void fill_digests_buf_linear_gpu_with_gpu_ptr_template(
         // printf("GPU Round (64) %u\n", r);
         last_index -= (1 << r);
         compute_internal_hashes_linear_all<H><<<((1 << r) * cap_buf_size) / TPB + 1, TPB>>>((u64 *)digests_buf_gpu_ptr, (1 << r), last_index, cap_buf_size, subtree_digests_len);
+        CHECKCUDAERR(cudaGetLastError());
     }
 
     for (; r > 0; r--)
@@ -230,6 +236,7 @@ void fill_digests_buf_linear_gpu_with_gpu_ptr_template(
         // printf("GPU Round (1) %u\n", r);
         last_index -= (1 << r);
         compute_internal_hashes_linear_all<H><<<1, TPB>>>((u64 *)digests_buf_gpu_ptr, (1 << r), last_index, cap_buf_size, subtree_digests_len);
+        CHECKCUDAERR(cudaGetLastError());
     }
 
     // compute cap hashes on GPU
@@ -241,6 +248,7 @@ void fill_digests_buf_linear_gpu_with_gpu_ptr_template(
     {
         compute_caps_hashes_linear<H><<<cap_buf_size / TPB + 1, TPB>>>((u64 *)cap_buf_gpu_ptr, (u64 *)digests_buf_gpu_ptr, cap_buf_size, subtree_digests_len);
     }
+    CHECKCUDAERR(cudaGetLastError());
 }
 
 void fill_digests_buf_linear_gpu_with_gpu_ptr(
@@ -295,20 +303,28 @@ void fill_digests_buf_linear_multigpu_with_gpu_ptr_template(
     int nDevices = 0;
     CHECKCUDAERR(cudaGetDeviceCount(&nDevices));
 
-    assert(nDevices <= 16);
-    assert(gpu_id < nDevices);
+    if (nDevices > 16)
+    {
+        fprintf(stderr, "zeknox: nDevices (%d) exceeds maximum supported (16)\n", nDevices);
+        return;
+    }
+    if ((int)gpu_id >= nDevices)
+    {
+        fprintf(stderr, "zeknox: gpu_id (%llu) >= nDevices (%d)\n", (unsigned long long)gpu_id, nDevices);
+        return;
+    }
 
-    cudaStream_t gpu_stream[16];
-    u64 *gpu_leaves_ptrs[16];
-    u64 *gpu_digests_ptrs[16];
-    u64 *gpu_caps_ptrs[16];
+    cudaStream_t gpu_stream[16] = {};
+    u64 *gpu_leaves_ptrs[16] = {};
+    u64 *gpu_digests_ptrs[16] = {};
+    u64 *gpu_caps_ptrs[16] = {};
     gpu_leaves_ptrs[gpu_id] = (u64 *)leaves_buf_gpu_ptr;
 
     // (special case) compute leaf hashes on GPU
     if (cap_buf_size == leaves_buf_size)
     {
         CHECKCUDAERR(cudaSetDevice(gpu_id));
-        CHECKCUDAERR(cudaStreamCreate(gpu_stream));
+        CHECKCUDAERR(cudaStreamCreate(&gpu_stream[gpu_id]));
         gpu_leaves_ptrs[gpu_id] = (u64 *)leaves_buf_gpu_ptr;
         gpu_caps_ptrs[gpu_id] = (u64 *)cap_buf_gpu_ptr;
         u64 leaves_per_gpu = leaves_buf_size * leaf_size / nDevices;

--- a/native/ntt/ntt.cu
+++ b/native/ntt/ntt.cu
@@ -498,7 +498,6 @@ namespace ntt {
             }
 
             size_t total_input_elements = (static_cast<size_t>(1 << lg_n)) * cfg.batches;
-            int input_size_bytes = total_input_elements * sizeof(fr_t);
 
             dev_ptr_t<fr_t> d_input{
                 total_input_elements,
@@ -515,7 +514,6 @@ namespace ntt {
             }
 
             size_t total_output_elements = size * (cfg.batches + cfg.salt_size);
-            int input_output_bytes = total_output_elements * sizeof(fr_t);
             dev_ptr_t<fr_t> d_output{
                 total_output_elements,
                 gpu,

--- a/wrappers/rust/benches/gpu_fft_batch.rs
+++ b/wrappers/rust/benches/gpu_fft_batch.rs
@@ -30,7 +30,7 @@ fn bench_gpu_ntt_batch(c: &mut Criterion) {
         let domain_size = 1usize << log_ntt_size;
         let batches = 200;
 
-        init_twiddle_factors_rs(0, log_ntt_size);
+        init_twiddle_factors_rs(0, log_ntt_size).unwrap();
 
         let total_elements = domain_size * batches;
         // let scalars: Vec<u64> = (0..(total_elements)).map(|_| random_fr()).collect();
@@ -64,7 +64,7 @@ fn bench_gpu_ntt_batch(c: &mut Criterion) {
                         device_data.as_mut_ptr(),
                         log_ntt_size,
                         cfg.clone(),
-                    )
+                    ).unwrap()
                 })
             },
         );

--- a/wrappers/rust/benches/lde_batch.rs
+++ b/wrappers/rust/benches/lde_batch.rs
@@ -23,19 +23,19 @@ fn random_fr() -> u64 {
 
 fn init_twiddle_gpu(lg_domain_size: usize, ngpus: usize) {
     for i in 0..ngpus {
-        init_twiddle_factors_rs(i, lg_domain_size);
+        init_twiddle_factors_rs(i, lg_domain_size).unwrap();
     }
 }
 
 fn init_coset(ngpus: usize) {
     for i in 0..ngpus {
-        init_coset_rs(i, 23, GoldilocksField::coset_shift().to_canonical_u64());
+        init_coset_rs(i, 23, GoldilocksField::coset_shift().to_canonical_u64()).unwrap();
     }
 }
 
 fn bench_multi_gpu_lde_batch(c: &mut Criterion) {
     let ngpus1: usize = env::var("NUM_OF_GPUS").unwrap().parse::<usize>().unwrap();
-    let ngpus2: usize = get_number_of_gpus_rs();
+    let ngpus2: usize = get_number_of_gpus_rs().unwrap();
     let ngpus = std::cmp::min(ngpus1, ngpus2);
 
     assert!(ngpus > 0);
@@ -93,7 +93,7 @@ fn bench_multi_gpu_lde_batch(c: &mut Criterion) {
                         log_n_sizes,
                         total_num_input_elements,
                         total_num_output_elements,
-                    )
+                    ).unwrap()
                 })
             },
         );
@@ -110,7 +110,7 @@ fn bench_multi_gpu_lde_batch(c: &mut Criterion) {
                         log_n_sizes,
                         total_num_input_elements,
                         total_num_output_elements,
-                    )
+                    ).unwrap()
                 })
             },
         );

--- a/wrappers/rust/benches/transpose.rs
+++ b/wrappers/rust/benches/transpose.rs
@@ -54,7 +54,7 @@ fn bench_transpose_gpu(c: &mut Criterion) {
                         device_data2.as_mut_ptr(),
                         log_ntt_size,
                         cfg.clone(),
-                    )
+                    ).unwrap()
                 })
             },
         );

--- a/wrappers/rust/build.rs
+++ b/wrappers/rust/build.rs
@@ -13,13 +13,26 @@ extern crate rustacuda;
 
 // based on: https://github.com/matter-labs/z-prize-msm-gpu/blob/main/bellman-cuda-rust/cudart-sys/build.rs
 #[cfg(not(feature = "no_cuda"))]
+fn cuda_home() -> PathBuf {
+    if let Ok(path) = env::var("CUDA_HOME") {
+        return PathBuf::from(path);
+    }
+    if let Ok(path) = env::var("CUDA_PATH") {
+        return PathBuf::from(path);
+    }
+    PathBuf::from("/usr/local/cuda")
+}
+
+#[cfg(not(feature = "no_cuda"))]
 fn build_device_wrapper() {
-    let cuda_runtime_api_path = PathBuf::from("/usr/local/cuda/include")
+    let cuda_root = cuda_home();
+    let cuda_runtime_api_path = cuda_root
+        .join("include")
         .join("cuda_runtime_api.h")
         .to_string_lossy()
         .to_string();
     let binding_path = PathBuf::from("src/device").join("bindings.rs");
-    println!("cargo:rustc-link-search=native={}", "/usr/local/cuda/lib64");
+    println!("cargo:rustc-link-search=native={}", cuda_root.join("lib64").to_str().unwrap());
     println!("cargo:rustc-link-lib=cudart");
     println!("cargo:rerun-if-changed={}", cuda_runtime_api_path);
     println!(
@@ -107,7 +120,7 @@ fn build_lib() {
     println!("cargo:rustc-link-search={}", libdir.to_str().unwrap());
 
     // Static lib
-    println!("cargo:rustc-link-search=native={}", "/usr/local/cuda/lib64");
+    println!("cargo:rustc-link-search=native={}", cuda_home().join("lib64").to_str().unwrap());
     println!("cargo:rustc-link-search=native={}", "/usr/local/lib");
     println!("cargo:rustc-link-lib=cudart");
     println!("cargo:rustc-link-lib=stdc++");

--- a/wrappers/rust/examples/ntt_batch.rs
+++ b/wrappers/rust/examples/ntt_batch.rs
@@ -45,7 +45,7 @@ fn ntt_batch_with_lg(batches: usize, log_ntt_size: usize) {
         device_data.as_mut_ptr(),
         log_ntt_size,
         cfg.clone(),
-    );
+    ).unwrap();
 
     println!("total time spend: {:?}", start.elapsed());
 }
@@ -54,7 +54,7 @@ fn main() {
     let start = std::time::Instant::now();
     println!("total time spend init context: {:?}", start.elapsed());
     let log_ntt_size = 19;
-    init_twiddle_factors_rs(0, log_ntt_size);
+    init_twiddle_factors_rs(0, log_ntt_size).unwrap();
 
     let batches = 10;
 

--- a/wrappers/rust/src/lib.rs
+++ b/wrappers/rust/src/lib.rs
@@ -106,23 +106,23 @@ pub fn list_devices_info_rs() {
     }
 }
 
-pub fn get_number_of_gpus_rs() -> usize {
+pub fn get_number_of_gpus_rs() -> Result<usize, String> {
     let mut nums = 0;
     let err = unsafe { get_number_of_gpus(&mut nums) };
 
     if err.code != 0 {
-        panic!("{}", String::from(err));
+        return Err(String::from(err));
     }
-    return nums;
+    Ok(nums)
 }
 
 pub fn lde_batch<T>(
     device_id: usize,
-    output: *mut T,  // &mut [T],
-    input: *const T, // &mut [T],
+    output: *mut T,
+    input: *const T,
     log_n_size: usize,
     cfg: NTTConfig,
-) {
+) -> Result<(), String> {
     let err = unsafe {
         compute_batched_lde(
             device_id,
@@ -135,21 +135,21 @@ pub fn lde_batch<T>(
     };
 
     if err.code != 0 {
-        panic!("{}", String::from(err));
+        return Err(String::from(err));
     }
+    Ok(())
 }
 
 pub fn lde_batch_multi_gpu<T>(
-    output: *mut T,  // &mut [T],
-    input: *const T, // &mut [T],
+    output: *mut T,
+    input: *const T,
     num_gpu: usize,
     cfg: NTTConfig,
     log_n_size: usize,
     total_num_input_elements: usize,
     total_num_output_elements: usize,
-) {
+) -> Result<(), String> {
     let err = unsafe {
-        // println!("In compute_batched_lde_multi_gpu {:?}", total_num_input_elements);
         compute_batched_lde_multi_gpu(
             output as *mut core::ffi::c_void,
             input as *mut core::ffi::c_void,
@@ -163,20 +163,20 @@ pub fn lde_batch_multi_gpu<T>(
     };
 
     if err.code != 0 {
-        panic!("{}", String::from(err));
+        return Err(String::from(err));
     }
+    Ok(())
 }
 
 pub fn ntt_batch<T>(
     device_id: usize,
-    inout: *mut T, // &mut [T],
+    inout: *mut T,
     log_n_size: usize,
     cfg: NTTConfig,
-) {
+) -> Result<(), String> {
     let err = unsafe {
         compute_batched_ntt(
             device_id,
-            // inout.as_mut_ptr() as *mut core::ffi::c_void,
             inout as *mut core::ffi::c_void,
             log_n_size,
             types::NTTDirection::Forward,
@@ -185,11 +185,12 @@ pub fn ntt_batch<T>(
     };
 
     if err.code != 0 {
-        panic!("{}", String::from(err));
+        return Err(String::from(err));
     }
+    Ok(())
 }
 
-pub fn intt_batch<T>(device_id: usize, inout: *mut T, log_n_size: usize, cfg: NTTConfig) {
+pub fn intt_batch<T>(device_id: usize, inout: *mut T, log_n_size: usize, cfg: NTTConfig) -> Result<(), String> {
     let err = unsafe {
         compute_batched_ntt(
             device_id,
@@ -201,17 +202,18 @@ pub fn intt_batch<T>(device_id: usize, inout: *mut T, log_n_size: usize, cfg: NT
     };
 
     if err.code != 0 {
-        panic!("{}", String::from(err));
+        return Err(String::from(err));
     }
+    Ok(())
 }
 
 pub fn transpose_rev_batch<T>(
     device_id: i32,
-    output: *mut T,  // &mut [T],
-    input: *const T, // &mut [T],
+    output: *mut T,
+    input: *const T,
     log_n_size: usize,
     cfg: TransposeConfig,
-) {
+) -> Result<(), String> {
     let err = unsafe {
         compute_transpose_rev(
             device_id,
@@ -223,24 +225,27 @@ pub fn transpose_rev_batch<T>(
     };
 
     if err.code != 0 {
-        panic!("{}", String::from(err));
+        return Err(String::from(err));
     }
+    Ok(())
 }
 
-pub fn init_twiddle_factors_rs(device_id: usize, lg_n: usize) {
+pub fn init_twiddle_factors_rs(device_id: usize, lg_n: usize) -> Result<(), String> {
     let err = unsafe { init_twiddle_factors(device_id, lg_n) };
 
     if err.code != 0 {
-        panic!("{}", String::from(err));
+        return Err(String::from(err));
     }
+    Ok(())
 }
 
-pub fn init_coset_rs(device_id: usize, lg_n: usize, coset_gen: u64) {
+pub fn init_coset_rs(device_id: usize, lg_n: usize, coset_gen: u64) -> Result<(), String> {
     let err = unsafe { init_coset(device_id, lg_n, coset_gen) };
 
     if err.code != 0 {
-        panic!("{}", String::from(err));
+        return Err(String::from(err));
     }
+    Ok(())
 }
 
 pub fn init_cuda_rs() {

--- a/wrappers/rust/tests/ntt.rs
+++ b/wrappers/rust/tests/ntt.rs
@@ -29,7 +29,7 @@ const DEFAULT_GPU: i32 = 0;
 #[test]
 fn test_ntt_batch_gl64_consistency_with_plonky2() {
     let lg_domain_size: usize = 4;
-    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size);
+    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size).unwrap();
     let domain_size = 1usize << lg_domain_size;
 
     let v1: Vec<u64> = (0..domain_size).map(|_| random_fr()).collect();
@@ -45,7 +45,7 @@ fn test_ntt_batch_gl64_consistency_with_plonky2() {
         gpu_buffer.as_mut_ptr(),
         lg_domain_size,
         cfg,
-    );
+    ).unwrap();
 
     let plonky2_ntt_input1 = v1.clone();
     let coeffs1 = plonky2_ntt_input1
@@ -84,7 +84,7 @@ fn test_ntt_batch_gl64_consistency_with_plonky2() {
 #[test]
 fn test_ntt_batch_intt_batch_gl64_self_consistency() {
     let lg_domain_size: usize = 10;
-    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size);
+    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size).unwrap();
     let domain_size = 1usize << lg_domain_size;
 
     let v1: Vec<u64> = (0..domain_size).map(|_| random_fr()).collect();
@@ -96,21 +96,21 @@ fn test_ntt_batch_intt_batch_gl64_self_consistency() {
         gpu_buffer.as_mut_ptr(),
         lg_domain_size,
         cfg.clone(),
-    );
+    ).unwrap();
 
     intt_batch(
         DEFAULT_GPU as usize,
         gpu_buffer.as_mut_ptr(),
         lg_domain_size,
         cfg.clone(),
-    );
+    ).unwrap();
     assert_eq!(v1, gpu_buffer);
 }
 
 #[test]
 fn test_intt_batch_gl64_consistency_with_plonky2() {
     let lg_domain_size: usize = 4;
-    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size);
+    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size).unwrap();
 
     let batches = 2;
     let domain_size = 1usize << lg_domain_size;
@@ -128,7 +128,7 @@ fn test_intt_batch_gl64_consistency_with_plonky2() {
         gpu_buffer.as_mut_ptr(),
         lg_domain_size,
         cfg,
-    );
+    ).unwrap();
 
     let plonky2_intt_input1 = input1.clone();
     let values1 = plonky2_intt_input1
@@ -169,7 +169,7 @@ fn test_ntt_on_device() {
     let lg_domain_size = 10;
     let domain_size = 1usize << lg_domain_size;
 
-    init_twiddle_factors_rs(0, lg_domain_size);
+    init_twiddle_factors_rs(0, lg_domain_size).unwrap();
 
     let scalars: Vec<u64> = (0..domain_size).map(|_| random_fr()).collect();
 
@@ -180,8 +180,8 @@ fn test_ntt_on_device() {
     let mut cfg = NTTConfig::default();
     cfg.are_inputs_on_device = true;
     cfg.are_outputs_on_device = true;
-    ntt_batch(0, device_data.as_mut_ptr(), lg_domain_size, cfg.clone());
-    intt_batch(0, device_data.as_mut_ptr(), lg_domain_size, cfg.clone());
+    ntt_batch(0, device_data.as_mut_ptr(), lg_domain_size, cfg.clone()).unwrap();
+    intt_batch(0, device_data.as_mut_ptr(), lg_domain_size, cfg.clone()).unwrap();
 
     let mut host_output = vec![0; domain_size];
     // println!("start copy to host");
@@ -197,7 +197,7 @@ fn test_ntt_batch_on_device() {
     let domain_size = 1usize << lg_domain_size;
     let batches = 2;
 
-    init_twiddle_factors_rs(0, lg_domain_size);
+    init_twiddle_factors_rs(0, lg_domain_size).unwrap();
 
     let total_elements = domain_size * batches;
     // let scalars: Vec<u64> = (0..(total_elements)).map(|_| random_fr()).collect();
@@ -219,7 +219,7 @@ fn test_ntt_batch_on_device() {
     cfg.are_outputs_on_device = true;
     cfg.batches = batches as u32;
     // println!("device data len: {:?}", device_data.len());
-    ntt_batch(0, device_data.as_mut_ptr(), lg_domain_size, cfg.clone());
+    ntt_batch(0, device_data.as_mut_ptr(), lg_domain_size, cfg.clone()).unwrap();
 
     let mut host_output = vec![0; total_elements];
     // println!("start copy to host");
@@ -315,7 +315,7 @@ fn test_transpose_rev() {
         device_data.as_mut_ptr(),
         lg_domain_size,
         cfg.clone(),
-    );
+    ).unwrap();
 
     let mut host_output = vec![0; total_elements];
     // println!("start copy to host");
@@ -335,12 +335,12 @@ fn test_ntt_batch_with_coset() {
     let domain_size = 1usize << lg_domain_size;
     // let batches = 2;
 
-    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size);
+    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size).unwrap();
     init_coset_rs(
         DEFAULT_GPU as usize,
         lg_domain_size,
         GoldilocksField::coset_shift().to_canonical_u64(),
-    );
+    ).unwrap();
 
     let v1: Vec<u64> = (0..domain_size).map(|_| random_fr()).collect();
     let v2: Vec<u64> = (0..domain_size).map(|_| random_fr()).collect();
@@ -356,7 +356,7 @@ fn test_ntt_batch_with_coset() {
         gpu_buffer.as_mut_ptr(),
         lg_domain_size,
         cfg.clone(),
-    );
+    ).unwrap();
 
     let cpu_buffer = v1.clone();
 
@@ -397,12 +397,12 @@ fn test_compute_batched_lde() {
     let rate_bits = 1;
     let lg_domain_size = lg_n + rate_bits;
     let batches = 2;
-    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size);
+    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size).unwrap();
     init_coset_rs(
         DEFAULT_GPU as usize,
         lg_domain_size,
         GoldilocksField::coset_shift().to_canonical_u64(),
-    );
+    ).unwrap();
 
     let input_size = 1usize << lg_n;
 
@@ -442,7 +442,7 @@ fn test_compute_batched_lde() {
         cpu_polys_coeffs.as_mut_ptr(),
         lg_domain_size,
         cfg,
-    );
+    ).unwrap();
 
     let cpu_outputs = cpu_polys_coeffs
         .iter()
@@ -474,7 +474,7 @@ fn test_compute_batched_lde() {
         gpu_buffer.as_mut_ptr(),
         lg_n,
         cfg_lde,
-    );
+    ).unwrap();
     assert_eq!(cpu_outputs, gpu_lde_output);
 }
 
@@ -487,12 +487,12 @@ fn test_compute_batched_lde_data_on_device() {
     let output_domain_size = 1usize << (lg_n + rate_bits);
     let batches = 2;
 
-    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size);
+    init_twiddle_factors_rs(DEFAULT_GPU as usize, lg_domain_size).unwrap();
     init_coset_rs(
         DEFAULT_GPU as usize,
         lg_domain_size,
         GoldilocksField::coset_shift().to_canonical_u64(),
-    );
+    ).unwrap();
 
     let total_num_input_elements = input_domain_size * batches;
     let total_num_output_elements = output_domain_size * batches;
@@ -531,7 +531,7 @@ fn test_compute_batched_lde_data_on_device() {
         device_input_data.as_mut_ptr(),
         lg_n,
         cfg_lde,
-    );
+    ).unwrap();
 
     let mut host_output_first = vec![0; output_domain_size];
     let mut host_output_last = vec![0; output_domain_size];
@@ -564,7 +564,7 @@ fn test_compute_batched_lde_data_on_device() {
         lde_copy_buffer.as_mut_ptr(),
         lg_n,
         cfg_lde_copy,
-    );
+    ).unwrap();
     assert_eq!(
         gpu_lde_output_copy[0..output_domain_size],
         host_output_first
@@ -584,16 +584,16 @@ fn test_compute_batched_lde_multi_gpu_data_on_one_gpu() {
     let output_domain_size = 1usize << (lg_n + rate_bits);
     let max_batches = 10;
 
-    let ngpus = get_number_of_gpus_rs();
+    let ngpus = get_number_of_gpus_rs().unwrap();
     assert!(ngpus > 1, "Number of GPUs must be greater than 1");
 
     for i in 0..ngpus {
-        init_twiddle_factors_rs(i as usize, lg_domain_size);
+        init_twiddle_factors_rs(i as usize, lg_domain_size).unwrap();
         init_coset_rs(
             i as usize,
             lg_domain_size,
             GoldilocksField::coset_shift().to_canonical_u64(),
-        );
+        ).unwrap();
     }
     // lde rust allocate to gpu prior to api call
     let mut device_output_data: HostOrDeviceSlice<'_, u64> =
@@ -632,7 +632,7 @@ fn test_compute_batched_lde_multi_gpu_data_on_one_gpu() {
             lg_n,
             total_num_input_elements,
             total_num_output_elements,
-        );
+        ).unwrap();
 
         let mut lde_multi_output = vec![0; batches * output_domain_size];
         let _ = device_output_data.copy_to_host_offset(
@@ -654,7 +654,7 @@ fn test_compute_batched_lde_multi_gpu_data_on_one_gpu() {
             host_inputs_copy.as_mut_ptr(),
             lg_n,
             cfg_lde_copy,
-        );
+        ).unwrap();
 
         assert!(lde_single_output == lde_multi_output);
     }


### PR DESCRIPTION
- merkle.cu: replace assert() with proper runtime checks that return early with stderr message instead of aborting in Release builds
- merkle.cu: zero-initialize gpu_stream/leaves/digests/caps pointer arrays to prevent use of garbage values during cleanup
- merkle.cu: fix cudaStreamCreate(gpu_stream) -> cudaStreamCreate(&gpu_stream[gpu_id]) so the stream is stored at the correct array index when gpu_id != 0
- merkle.cu: add CHECKCUDAERR(cudaGetLastError()) after all kernel launches in the single-GPU path to catch silent kernel failures
- ntt.cu: remove unused int input_size_bytes / input_output_bytes variables that would overflow for inputs > ~256 MB
- build.rs: respect CUDA_HOME / CUDA_PATH env vars with fallback to /usr/local/cuda instead of always using the hardcoded path
- lib.rs: convert all panic-on-error functions to return Result<T, String>
  so callers can handle CUDA errors without a process crash